### PR TITLE
feat(timeline): Add support for color and colormaps to broken bar plots .

### DIFF
--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -539,25 +539,47 @@ class TimeLineDock(QWidget):
         )
 
     def add_timeline_broken_bar(
-        self, timeline_row_name: str, start_and_stop_times, item_name: str = ""
+        self,
+        timeline_row_name: str,
+        data: list[tuple[float, float, float]] | list[tuple[float, float]],
+        item_name: str = "",
+        color: str = "white",
     ) -> None:
+        """Adds a broken bar plot to the timeline where bars are colored based on a Z-value.
+
+        Args:
+            timeline: The instance of TimeLineDock.
+            timeline_row_name: The name of the row (y-axis label).
+            data: A list of tuples (start, stop, value) or (start, stop).
+                  'value' is used for the colormap.
+            item_name: Name for the legend.
+            color: Name of the pyqtgraph colormap or color(e.g., 'viridis', 'white', ...)
+        """
         plot_widget = self.get_timeline_plot(timeline_row_name, True)
         plot_widget.getViewBox().allow_y_panning = False
+        # plot_widget.getViewBox().setMouseEnabled(y=False)
+        # plot_widget.setMenuEnabled(False)
 
-        pen = pg.mkPen("white")
-        brush = pg.mkBrush("white")
+        columns = list(zip(*data, strict=False))
+        starts_raw, stops_raw = (
+            np.array(columns[0], dtype=np.float64),
+            np.array(columns[1], dtype=np.float64),
+        )
 
-        # data is a list of (start, end) tuples
-        starts = [t[0] for t in start_and_stop_times]
-        stops = [t[1] for t in start_and_stop_times]
+        valid_mask = stops_raw >= starts_raw
+        if not np.all(valid_mask):
+            stops_raw = np.maximum(starts_raw, stops_raw)
+
+        values = (
+            np.array(columns[2], dtype=np.float64)
+            if len(columns) > 2
+            else np.full(len(starts_raw), np.nan)
+        )
+        color_values = values if not np.all(np.isnan(values)) else np.array([])
+        pens, brushes = _resolve_bar_colors(color_values, color, len(starts_raw))
 
         bars = pg.BarGraphItem(
-            x0=starts,
-            x1=stops,
-            y0=-0.4,
-            y1=0.4,
-            pen=pen,
-            brush=brush,
+            x0=starts_raw, x1=stops_raw, y0=-0.4, y1=0.4, pens=pens, brushes=brushes
         )
         plot_widget.addItem(bars)
 
@@ -635,3 +657,28 @@ class TimeLineDock(QWidget):
     def set_export_window(self, times: list[int]) -> None:
         self.trim_markers[0].time = times[0]
         self.trim_markers[1].time = times[1]
+
+
+def _resolve_bar_colors(
+    values: np.ndarray, color_arg: str = "white", count: int = 1
+) -> tuple[list, list]:
+    """Determine pen and brush colors for bars based on values and color arg."""
+    if values.size == 0 or np.all(np.isnan(values)):
+        c = pg.mkColor(color_arg)
+        pen = pg.mkPen(c)
+        brush = pg.mkBrush(c)
+        return [pen] * count, [brush] * count
+
+    min_v, max_v = np.min(values), np.max(values)
+    if max_v == min_v:
+        norm_values = np.full_like(values, 0.5)
+    else:
+        norm_values = (values - min_v) / (max_v - min_v)
+
+    try:
+        cmap = pg.colormap.get(color_arg)
+    except Exception:
+        cmap = pg.colormap.get("viridis")
+
+    colors = cmap.map(norm_values, mode="qcolor")
+    return [pg.mkPen(c) for c in colors], [pg.mkBrush(c) for c in colors]


### PR DESCRIPTION
# PR - Add color and colormaps to broken bars.

## Motivation
Many white bars can be difficult to interpret at a glance, without looking at the labels, specially since we do not have hierarchy yet. By adding color to the broken bars and the possibility to add colormap based values, it makes it more discoverable/ easy to interpret.

**Use cases:** 
- Show number of detections at a glance or whether an object is being gazed.
- Mimic enrichments bar on Cloud as surface detected or gazed.

## Proposed Solution

**Example:**
<img width="1712" height="1140" alt="Screenshot 2025-12-16 at 12 57 43" src="https://github.com/user-attachments/assets/00c8edf3-3096-4530-b6a6-7143fe3aa8d9" />

## Key Changes
- Accept data with optional Z-values for color mapping.
- Implemented `_resolve_bar_colors` to determine pen and brush colors based on values.

