### PR TITLE
Fix event loading, right-click and delete

### DIFF
--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -232,10 +232,21 @@ class EventsPlugin(neon_player.Plugin):
         self._update_timeline_data(event_type)
 
     def delete_event_instance(self, timeline_name, data_point, event_type) -> None:
-        self.events[event_type.uid].remove(data_point[0])
+        if event_type.uid not in self.events:
+            return
 
-        self.save_cached_json("events.json", self.events)
-        self._update_timeline_data(event_type)
+        events_list = self.events[event_type.uid]
+        target_ts = data_point[0]
+
+        if not events_list:
+            return
+
+        closest_event = min(events_list, key=lambda x: abs(x - target_ts))
+
+        if abs(closest_event - target_ts) < 5:
+            events_list.remove(closest_event)
+            self.save_cached_json("events.json", self.events)
+            self._update_timeline_data(event_type)
 
     def seek_to_event_instance(self, data_point) -> None:
         self.app.seek_to(data_point[0])

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -4,6 +4,7 @@ from pathlib import Path
 
 import numpy as np
 import pandas as pd
+from pupil_labs.neon_recording import NeonRecording
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtGui import QIcon, QKeyEvent
 from qt_property_widgets.utilities import (
@@ -16,7 +17,6 @@ from qt_property_widgets.utilities import (
 from pupil_labs import neon_player
 from pupil_labs.neon_player import GlobalPluginProperties, action
 from pupil_labs.neon_player.ui import ListPropertyAppenderAction
-from pupil_labs.neon_recording import NeonRecording
 
 IMMUTABLE_EVENTS = ["recording.begin", "recording.end"]
 
@@ -104,18 +104,39 @@ class EventsPlugin(neon_player.Plugin):
             logging.exception("Failed to load events json")
             cached_events = None
 
+        types_to_update = set()
+
         if cached_events is None:
+            type_cache = {et.name: et for et in self._event_types}
+
             for event in self.recording.events:
-                et = self.create_event_type(str(event.event))
-                if event.event in IMMUTABLE_EVENTS:
-                    et.uid = str(event.event)
+                evt_name = str(event.event)
 
-                self.add_event(et, event.time)
+                if evt_name in type_cache:
+                    et = type_cache[evt_name]
+                else:
+                    et = self.get_event_type_by_name(evt_name)
+                    if et is None:
+                        et = self.create_event_type(evt_name)
 
-            recording_event_names = [et.name for et in self._event_types]
+                    if evt_name in IMMUTABLE_EVENTS:
+                        et.uid = evt_name
+
+                    type_cache[evt_name] = et
+                    types_to_update.add(et)
+
+                # Add to memory
+                if et.uid not in self.events:
+                    self.events[et.uid] = []
+                self.events[et.uid].append(event.time)
+
+            recording_event_names = list(type_cache.keys())
             for event_name in self.global_properties.global_event_types:
                 if event_name not in recording_event_names:
                     self.create_event_type(event_name)
+
+            self.save_cached_json("events.json", self.events)
+
         else:
             self.events = cached_events
             for uid in self.events:
@@ -126,14 +147,19 @@ class EventsPlugin(neon_player.Plugin):
                     et = self.get_event_type(uid)
 
                 self._setup_gui_for_event_type(et)
+                types_to_update.add(et)
+
+        logging.info(f"Loaded {sum(len(v) for v in self.events.values())} events")
+
+        timeline = self.get_timeline()
+        timeline.setUpdatesEnabled(False)
+        try:
+            for et in types_to_update:
+                self._setup_gui_for_event_type(et)
                 self._update_timeline_data(et)
-
-        for event_uid in self.events:
-            if event_uid in IMMUTABLE_EVENTS:
-                continue
-
-            event_type = self.get_event_type(event_uid)
-            self._update_timeline_data(event_type)
+        finally:
+            timeline.setUpdatesEnabled(True)
+            timeline.sort_plots()
 
     def get_event_type(self, uid: str) -> EventType:
         for event_type in self._event_types:
@@ -219,15 +245,20 @@ class EventsPlugin(neon_player.Plugin):
         event_name = event_type.name
         plot_item = timeline.get_timeline_plot(f"Events - {event_name}", True)
 
-        events = self.events.get(event_type.uid, [])
+        raw_events = self.events.get(event_type.uid, [])
+        if raw_events:
+            data = np.array([[t, 0] for t in raw_events], dtype=np.float64)
+        else:
+            data = np.empty((0, 2))
 
         if len(plot_item.items) == 0:
-            plot_item = timeline.add_timeline_scatter(
-                f"Events - {event_name}",
-                np.array([[t, 0] for t in events]),
-            )
+            if len(data) > 0:
+                plot_item = timeline.add_timeline_scatter(
+                    f"Events - {event_name}",
+                    data,
+                )
         else:
-            plot_item.items[0].setData(np.array([[t, 0] for t in events]))
+            plot_item.items[0].setData(data)
 
     @property
     @property_params(
@@ -309,15 +340,26 @@ class EventsPlugin(neon_player.Plugin):
     )
     def import_csv(self, source: FilePath):
         events_df = pd.read_csv(source)
-        for _, row in events_df.iterrows():
-            if row["name"] in IMMUTABLE_EVENTS:
+        modified_types = set()
+
+        for name, group in events_df.groupby("name"):
+            if name in IMMUTABLE_EVENTS:
                 continue
 
-            event_type = self.get_event_type_by_name(row["name"])
+            event_type = self.get_event_type_by_name(name)
             if event_type is None:
-                event_type = self.create_event_type(row["name"])
+                event_type = self.create_event_type(name)
 
-            self.add_event(event_type, row["timestamp [ns]"])
+            if event_type.uid not in self.events:
+                self.events[event_type.uid] = []
+
+            self.events[event_type.uid].extend(group["timestamp [ns]"].tolist())
+            modified_types.add(event_type)
+
+        self.save_cached_json("events.json", self.events)
+
+        for et in modified_types:
+            self._update_timeline_data(et)
 
     @action
     @action_params(compact=True, icon=QIcon(str(neon_player.asset_path("export.svg"))))

--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -8,7 +8,7 @@ from pyqtgraph.GraphicsScene.mouseEvents import (
     MouseDragEvent,
 )
 from PySide6.QtCore import QPoint, QPointF, QSize, Qt, Signal
-from PySide6.QtGui import QColor, QIcon, QKeyEvent
+from PySide6.QtGui import QColor, QCursor, QIcon, QKeyEvent
 from PySide6.QtWidgets import (
     QComboBox,
     QGraphicsSceneMouseEvent,
@@ -211,7 +211,7 @@ class TimeLineDock(QWidget):
             self.timestamps_plot.setXRange(
                 view_range[0] + playhead_adjust,
                 view_range[1] + playhead_adjust,
-                padding=0
+                padding=0,
             )
 
         self.timestamp_label.set_time(t - app.recording.start_time)
@@ -238,7 +238,33 @@ class TimeLineDock(QWidget):
             self.on_chart_area_clicked(event)
 
         elif event.button() == Qt.RightButton:
-            self.show_context_menu(event.globalPos())
+            view_pos = self.graphics_view.mapFrom(
+                self.graphics_view_container, event.pos()
+            )
+            scene_pos = self.graphics_view.mapToScene(view_pos)
+
+            class SyntheticEvent:
+                def __init__(self, scene_pos, screen_pos):
+                    self._scene_pos = scene_pos
+                    self._screen_pos = screen_pos
+
+                def scenePos(self):
+                    return self._scene_pos
+
+                def screenPos(self):
+                    return self._screen_pos
+
+                def globalPos(self):
+                    return self._screen_pos
+
+                def isAccepted(self):
+                    return False
+
+                def accept(self):
+                    pass
+
+            synth_event = SyntheticEvent(scene_pos, event.globalPos())
+            self.check_for_data_item_click(synth_event)
 
     def on_trim_area_drag_start(self, event: MouseDragEvent):
         app = neon_player.instance()
@@ -326,17 +352,50 @@ class TimeLineDock(QWidget):
         for item in nearby_items:
             if isinstance(item, pg.PlotItem):
                 clicked_plot_item = item
-            elif isinstance(item, pg.ScatterPlotItem):
-                p = item.mapFromScene(event.scenePos())
-                points_at = item.pointsAt(p)
-                if len(points_at) == 0:
-                    continue
+                break
+            if isinstance(item, pg.ViewBox) and isinstance(
+                item.parentItem(), pg.PlotItem
+            ):
+                clicked_plot_item = item.parentItem()
+                break
 
-                spot_item = points_at[0].pos()
-                clicked_data_point = (spot_item.x(), spot_item.y())
+        if clicked_plot_item:
+            for item in clicked_plot_item.items:
+                target_item = item
+                if (
+                    isinstance(item, pg.PlotDataItem)
+                    and hasattr(item, "scatter")
+                    and isinstance(item.scatter, pg.ScatterPlotItem)
+                ):
+                    target_item = item.scatter
+
+                if isinstance(target_item, pg.ScatterPlotItem):
+                    p = target_item.mapFromScene(event.scenePos())
+                    points_at = target_item.pointsAt(p)
+                    if len(points_at) > 0:
+                        spot_item = points_at[0].pos()
+                        clicked_data_point = (spot_item.x(), spot_item.y())
+                        break
+
+                    min_dist = 10  # pixels
+                    closest_spot = None
+
+                    for point in target_item.points():
+                        point_scene_pos = target_item.mapToScene(point.pos())
+                        diff = point_scene_pos - event.scenePos()
+                        dist = (diff.x() ** 2 + diff.y() ** 2) ** 0.5
+
+                        if dist < min_dist:
+                            min_dist = dist
+                            closest_spot = point
+
+                    if closest_spot:
+                        spot_pos = closest_spot.pos()
+                        clicked_data_point = (spot_pos.x(), spot_pos.y())
+                        break
 
         if clicked_plot_item is None or clicked_data_point is None:
-            self.show_context_menu(event.screenPos().toPoint())
+            self.show_context_menu(QCursor.pos())
             event.accept()
             return
 
@@ -526,7 +585,7 @@ class TimeLineDock(QWidget):
             action = context_menu.addAction(action_name)
             action.triggered.connect(lambda _, cb=callback: cb(data_point))
 
-        context_menu.exec(QPoint(event.screenPos().toQPoint()))
+        context_menu.exec(QCursor.pos())
 
     def add_timeline_line(
         self,


### PR DESCRIPTION
Fixes loading recordings with too many events, where sorting the timeline plots on every single event caused the app to hang. 

This PR addresses this by disabling and renabling timeline updates after all events are loaded, subsequently calling to sort.

As a bonus point, It also loads the event data faster.

This PR also addresses the error where you could not right-click on an event to Seek or delete.

And a bug when trying to delete events, where precision loss converting from float to int prevented some events to be deleted.


