### PR TITLE
fix(events): improve events in the timeline and fix tooltip display

### DIFF
--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -3,6 +3,7 @@ import typing as T
 from pathlib import Path
 
 from numpyencoder import NumpyEncoder
+from pupil_labs.neon_recording import NeonRecording
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtGui import QPainter
 from qt_property_widgets.utilities import PersistentPropertiesMixin, property_params
@@ -10,7 +11,6 @@ from qt_property_widgets.utilities import PersistentPropertiesMixin, property_pa
 from pupil_labs import neon_player
 from pupil_labs.neon_player.ui import QtShortcutType
 from pupil_labs.neon_player.ui.timeline_dock import TimeLineDock
-from pupil_labs.neon_recording import NeonRecording
 
 if T.TYPE_CHECKING:
     from pupil_labs.neon_player.app import NeonPlayerApp
@@ -62,6 +62,9 @@ class Plugin(PersistentPropertiesMixin, QObject):
         self.app.main_window.timeline.register_data_point_action(
             event_name, action_name, callback
         )
+
+    def unregister_data_point_actions(self, event_name: str) -> None:
+        self.app.main_window.timeline.unregister_data_point_actions(event_name)
 
     def add_dynamic_action(self, name: str, func: T.Callable) -> None:
         my_prop_form = self.app.main_window.settings_panel.plugin_class_expanders[

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -634,6 +634,9 @@ class EventsPlugin(neon_player.Plugin):
                     old_name
                 )
 
+            if old_name in timeline.hover_lines:
+                timeline.hover_lines[new_name] = timeline.hover_lines.pop(old_name)
+
             legend_container = timeline.timeline_legends[new_name].parentItem()
             for item in legend_container.items:
                 if isinstance(item, pg.LabelItem):

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -1,12 +1,22 @@
+import contextlib
 import logging
 import uuid
 from pathlib import Path
 
 import numpy as np
 import pandas as pd
+import pyqtgraph as pg
 from pupil_labs.neon_recording import NeonRecording
-from PySide6.QtCore import QObject, Signal
+from PySide6.QtCore import QObject, Qt, Signal
 from PySide6.QtGui import QIcon, QKeyEvent
+from PySide6.QtWidgets import (
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMenu,
+    QToolButton,
+    QWidget,
+)
 from qt_property_widgets.utilities import (
     FilePath,
     PersistentPropertiesMixin,
@@ -81,12 +91,31 @@ class EventsPlugin(neon_player.Plugin):
     def __init__(self) -> None:
         super().__init__()
         self._event_types: list[EventType] = []
+        self.events: dict[str, list[int]] = {}
+        self.events_expanded = True
+        self.events_search = ""
         self.get_timeline().key_pressed.connect(self._on_key_pressed)
         self.header_action = ListPropertyAppenderAction(
             "event_types", "+ Add event type"
         )
 
+        self.register_data_point_action(
+            "00_Events",
+            "Seek to this event",
+            self.seek_to_event_instance,
+        )
+        self.register_data_point_action(
+            "00_Events",
+            "Delete event instance",
+            self.delete_event_from_aggregate,
+        )
+
     def _on_key_pressed(self, event: QKeyEvent) -> None:
+        if event.key() == Qt.Key_Q and hasattr(self, "search_input"):
+            self.search_input.setFocus()
+            self.search_input.selectAll()
+            return
+
         key_text = event.text().lower()
         if key_text == "":
             return
@@ -103,8 +132,6 @@ class EventsPlugin(neon_player.Plugin):
         except Exception:
             logging.exception("Failed to load events json")
             cached_events = None
-
-        types_to_update = set()
 
         if cached_events is None:
             type_cache = {et.name: et for et in self._event_types}
@@ -123,12 +150,12 @@ class EventsPlugin(neon_player.Plugin):
                         et.uid = evt_name
 
                     type_cache[evt_name] = et
-                    types_to_update.add(et)
 
-                # Add to memory
                 if et.uid not in self.events:
                     self.events[et.uid] = []
-                self.events[et.uid].append(event.time)
+
+                if event.time not in self.events[et.uid]:
+                    self.events[et.uid].append(event.time)
 
             recording_event_names = list(type_cache.keys())
             for event_name in self.global_properties.global_event_types:
@@ -141,22 +168,19 @@ class EventsPlugin(neon_player.Plugin):
             self.events = cached_events
             for uid in self.events:
                 if uid in IMMUTABLE_EVENTS:
-                    et = self.create_event_type(uid)
-                    et.uid = uid
+                    et = self.get_event_type_by_name(uid)
+                    if et is None:
+                        et = self.create_event_type(uid)
+                        et.uid = uid
                 else:
                     et = self.get_event_type(uid)
-
-                self._setup_gui_for_event_type(et)
-                types_to_update.add(et)
 
         logging.info(f"Loaded {sum(len(v) for v in self.events.values())} events")
 
         timeline = self.get_timeline()
         timeline.setUpdatesEnabled(False)
         try:
-            for et in types_to_update:
-                self._setup_gui_for_event_type(et)
-                self._update_timeline_data(et)
+            self._update_all_timeline_data()
         finally:
             timeline.setUpdatesEnabled(True)
             timeline.sort_plots()
@@ -173,49 +197,258 @@ class EventsPlugin(neon_player.Plugin):
             return
 
         timeline = self.get_timeline()
-        timeline.remove_timeline_plot("Events")
+        timeline.remove_timeline_plot("00_Events")
+        timeline.remove_timeline_plot("01_Events_Search")
         for et in self._event_types:
-            timeline.remove_timeline_plot(f"Events - {et.name}")
+            timeline.remove_timeline_plot(et.name)
 
         for plot_name in IMMUTABLE_EVENTS:
-            timeline.remove_timeline_plot(f"Events - {plot_name}")
+            timeline.remove_timeline_plot(plot_name)
+
+    def _populate_add_menu(self, menu: QMenu):
+        menu.clear()
+        source_menu = self.app.main_window.get_menu("Timeline/Add Event")
+        for action in source_menu.actions():
+            menu.addAction(action)
+
+    def _create_event_type_dialog(self):
+        from PySide6.QtWidgets import QInputDialog
+
+        name, ok = QInputDialog.getText(
+            None, "Create Event Type", "Enter event type name:"
+        )
+        if ok and name:
+            self.create_event_type(name)
+
+    def _setup_events_header(self):
+        timeline = self.get_timeline()
+        if timeline.get_timeline_plot("00_Events", create_if_missing=False) is not None:
+            return
+
+        header_widget = QWidget()
+        layout = QHBoxLayout(header_widget)
+        layout.setContentsMargins(5, 0, 0, 0)
+        layout.setSpacing(4)
+
+        self.btn_toggle = QToolButton()
+        self.btn_toggle.setArrowType(
+            Qt.ArrowType.DownArrow if self.events_expanded else Qt.ArrowType.RightArrow
+        )
+        self.btn_toggle.clicked.connect(self._toggle_events)
+        self.btn_toggle.setStyleSheet(
+            "QToolButton { border: none; padding: 0; color: #ccc; } QToolButton::menu-indicator { image: none; }"
+        )
+
+        lbl = QLabel("Events")
+        lbl.setStyleSheet("color: #969696; font-weight: normal; font-size: 13px;")
+
+        layout.addWidget(lbl)
+        layout.addStretch()
+        layout.addWidget(self.btn_toggle)
+
+        self.btn_toggle.setPopupMode(QToolButton.ToolButtonPopupMode.DelayedPopup)
+        menu = QMenu(self.btn_toggle)
+
+        create_action = menu.addAction("Create Event Type...")
+        create_action.triggered.connect(self._create_event_type_dialog)
+
+        menu.addSeparator()
+
+        add_menu = menu.addMenu("Add Event Instance")
+        add_menu.aboutToShow.connect(lambda: self._populate_add_menu(add_menu))
+        self.btn_toggle.setMenu(menu)
+
+        plot_item = timeline.get_timeline_plot(
+            "00_Events", True, legend_widget=header_widget, sort_name="00_events"
+        )
+        plot_item.getViewBox().allow_y_panning = False
+        plot_item.setYRange(-0.5, 0.5)
+
+        if not any(isinstance(i, pg.PlotDataItem) for i in plot_item.items):
+            timeline.add_timeline_scatter("00_Events", [], is_event=True)
+
+    def _toggle_events(self):
+        self.events_expanded = not self.events_expanded
+        timeline = self.get_timeline()
+        timeline.setUpdatesEnabled(False)
+        try:
+            self._update_all_timeline_data()
+        finally:
+            timeline.setUpdatesEnabled(True)
+            timeline.sort_plots()
+
+    def _on_search_changed(self, text):
+        self.events_search = text.lower()
+        timeline = self.get_timeline()
+
+        had_focus = self.search_input.hasFocus()
+        cursor_pos = self.search_input.cursorPosition()
+
+        timeline.setUpdatesEnabled(False)
+        try:
+            self._update_all_timeline_data()
+        finally:
+            timeline.setUpdatesEnabled(True)
+            timeline.sort_plots()
+
+        if had_focus and hasattr(self, "search_input"):
+            self.search_input.setFocus()
+            self.search_input.setCursorPosition(cursor_pos)
+
+    def _update_all_timeline_data(self):
+        self._setup_events_header()
+        timeline = self.get_timeline()
+
+        if hasattr(self, "btn_toggle"):
+            self.btn_toggle.setArrowType(
+                Qt.ArrowType.DownArrow
+                if self.events_expanded
+                else Qt.ArrowType.RightArrow
+            )
+
+        all_events_info = []
+        for uid, times in self.events.items():
+            if uid in IMMUTABLE_EVENTS:
+                et_name = uid
+            else:
+                try:
+                    et = self.get_event_type(uid)
+                    et_name = et.name
+                except ValueError:
+                    continue
+
+            sorted_times = sorted(times)
+            total = len(sorted_times)
+            for i, t in enumerate(sorted_times):
+                all_events_info.append({
+                    "ts": t,
+                    "name": et_name,
+                    "rep": f" ({i + 1}/{total})" if total > 1 else "",
+                })
+
+        all_events_info.sort(key=lambda x: x["ts"])
+        all_events_data = (
+            np.array([[x["ts"], 0] for x in all_events_info], dtype=np.float64)
+            if all_events_info
+            else np.empty((0, 2))
+        )
+        all_events_names = [x["name"] for x in all_events_info]
+        all_events_reps = [x["rep"] for x in all_events_info]
+
+        plot_item = timeline.get_timeline_plot("00_Events", False)
+        if plot_item:
+            scatter_item = next(
+                (item for item in plot_item.items if isinstance(item, pg.PlotDataItem)),
+                None,
+            )
+            if scatter_item is None:
+                scatter_item = timeline.add_timeline_scatter(
+                    "00_Events", all_events_data, is_event=True
+                )
+            else:
+                scatter_item.setData(all_events_data)
+
+            scatter_item.custom_names = all_events_names
+            scatter_item.custom_reps = all_events_reps
+
+        if not self.events_expanded:
+            timeline.remove_timeline_plot("01_Events_Search")
+        else:
+            if not timeline.get_timeline_plot("01_Events_Search", False):
+                search_widget = QWidget()
+                search_layout = QHBoxLayout(search_widget)
+                search_layout.setContentsMargins(5, 0, 0, 0)
+
+                self.search_input = QLineEdit()
+                self.search_input.setText(self.events_search)
+                self.search_input.setPlaceholderText("Q Search")
+                self.search_input.setStyleSheet(
+                    "background: transparent; border: none; color: #888; font-size: 13px;"
+                )
+                self.search_input.textChanged.connect(self._on_search_changed)
+                search_layout.addWidget(self.search_input)
+
+                search_plot = timeline.get_timeline_plot(
+                    "01_Events_Search",
+                    True,
+                    legend_widget=search_widget,
+                    sort_name="01_events_search",
+                )
+                search_plot.getViewBox().allow_y_panning = False
+                search_plot.hideAxis("top")
+                search_plot.hideAxis("bottom")
+                search_plot.hideAxis("left")
+
+        for uid in list(self.events.keys()):
+            try:
+                et = self.get_event_type(uid)
+            except ValueError:
+                et = self.get_event_type_by_name(uid)
+
+            if et is None:
+                continue
+
+            et_name = et.name
+            matches_search = self.events_search in et_name.lower()
+
+            if not self.events_expanded or not matches_search:
+                timeline.remove_timeline_plot(et_name)
+            else:
+                self._setup_gui_for_event_type(et)
+                self._update_timeline_data(et)
 
     def _setup_gui_for_event_type(self, event_type: EventType) -> None:
         timeline = self.get_timeline()
-        existing_plot = timeline.get_timeline_plot(
-            f"Events - {event_type.name}", create_if_not_exists=False
-        )
-        if existing_plot is not None:
-            return
 
-        plot_item = timeline.add_timeline_scatter(f"Events - {event_type.name}", [])
-        plot_item.getViewBox().allow_y_panning = False
+        def register_data_actions():
+            self.unregister_data_point_actions(event_type.name)
+            if event_type.name not in IMMUTABLE_EVENTS:
+                self.register_data_point_action(
+                    event_type.name,
+                    f"Delete {event_type.name} instance",
+                    lambda data_point, et=event_type: self.delete_event_instance(
+                        event_type.name, data_point, et
+                    ),
+                )
+
+            self.register_data_point_action(
+                event_type.name,
+                f"Seek to this {event_type.name}",
+                self.seek_to_event_instance,
+            )
+
+        existing_plot = timeline.get_timeline_plot(
+            event_type.name, create_if_missing=False
+        )
+
+        if existing_plot is not None:
+            if any(isinstance(i, pg.PlotDataItem) for i in existing_plot.items):
+                register_data_actions()
+                return
+            plot_item = existing_plot
+        else:
+            plot_item = timeline.get_timeline_plot(
+                event_type.name, create_if_missing=True
+            )
+            plot_item.getViewBox().allow_y_panning = False
+            plot_item.setYRange(-0.5, 0.5)
+
+        timeline.add_timeline_scatter(event_type.name, [], is_event=True)
 
         if event_type.name not in IMMUTABLE_EVENTS:
             action = self.register_timeline_action(
                 f"Add Event/{event_type.name}", None, lambda: self.add_event(event_type)
             )
             self.app.main_window.sort_action_menu("Timeline/Add Event")
+
+            with contextlib.suppress(RuntimeError):
+                event_type.name_changed.disconnect()
             event_type.name_changed.connect(lambda old, new: action.setText(new))
 
-        def register_data_actions():
-            if event_type.name not in IMMUTABLE_EVENTS:
-                self.register_data_point_action(
-                    f"Events - {event_type.name}",
-                    f"Delete {event_type.name} instance",
-                    lambda data_point, et=event_type: self.delete_event_instance(
-                        f"Events - {event_type.name}", data_point, et
-                    ),
-                )
-
-            self.register_data_point_action(
-                f"Events - {event_type.name}",
-                f"Seek to this {event_type.name}",
-                self.seek_to_event_instance,
-            )
-
         register_data_actions()
-        event_type.name_changed.connect(lambda _, _2: register_data_actions())
+        with contextlib.suppress(RuntimeError):
+            event_type.changed.disconnect(self.changed.emit)
+        event_type.changed.connect(self.changed.emit)
 
     def add_event(self, event_type: EventType, ts: int | None = None) -> None:
         if self.recording is None:
@@ -227,9 +460,18 @@ class EventsPlugin(neon_player.Plugin):
         if event_type.uid not in self.events:
             self.events[event_type.uid] = []
 
+        if ts in self.events[event_type.uid]:
+            return
+
         self.events[event_type.uid].append(ts)
         self.save_cached_json("events.json", self.events)
-        self._update_timeline_data(event_type)
+        timeline = self.get_timeline()
+        timeline.setUpdatesEnabled(False)
+        try:
+            self._update_all_timeline_data()
+        finally:
+            timeline.setUpdatesEnabled(True)
+            timeline.sort_plots()
 
     def delete_event_instance(self, timeline_name, data_point, event_type) -> None:
         if event_type.uid not in self.events:
@@ -246,7 +488,40 @@ class EventsPlugin(neon_player.Plugin):
         if abs(closest_event - target_ts) < 5:
             events_list.remove(closest_event)
             self.save_cached_json("events.json", self.events)
-            self._update_timeline_data(event_type)
+            timeline = self.get_timeline()
+            timeline.setUpdatesEnabled(False)
+            try:
+                self._update_all_timeline_data()
+            finally:
+                timeline.setUpdatesEnabled(True)
+                timeline.sort_plots()
+
+    def delete_event_from_aggregate(self, data_point) -> None:
+        target_ts = data_point[0]
+        best_dist = float("inf")
+        best_et = None
+        best_ts = None
+
+        for uid, times in self.events.items():
+            if uid in IMMUTABLE_EVENTS:
+                continue
+            try:
+                et = self.get_event_type(uid)
+            except ValueError:
+                continue
+
+            if not times:
+                continue
+
+            closest = min(times, key=lambda x: abs(x - target_ts))
+            dist = abs(closest - target_ts)
+            if dist < best_dist:
+                best_dist = dist
+                best_et = et
+                best_ts = closest
+
+        if best_et and best_dist < 5:
+            self.delete_event_instance("00_Events", (best_ts, 0), best_et)
 
     def seek_to_event_instance(self, data_point) -> None:
         self.app.seek_to(data_point[0])
@@ -254,7 +529,7 @@ class EventsPlugin(neon_player.Plugin):
     def _update_timeline_data(self, event_type: EventType) -> None:
         timeline = self.get_timeline()
         event_name = event_type.name
-        plot_item = timeline.get_timeline_plot(f"Events - {event_name}", True)
+        plot_item = timeline.get_timeline_plot(event_name, True)
 
         raw_events = self.events.get(event_type.uid, [])
         if raw_events:
@@ -262,14 +537,19 @@ class EventsPlugin(neon_player.Plugin):
         else:
             data = np.empty((0, 2))
 
-        if len(plot_item.items) == 0:
-            if len(data) > 0:
-                plot_item = timeline.add_timeline_scatter(
-                    f"Events - {event_name}",
-                    data,
-                )
+        scatter_item = next(
+            (item for item in plot_item.items if isinstance(item, pg.PlotDataItem)),
+            None,
+        )
+
+        if scatter_item is None:
+            timeline.add_timeline_scatter(
+                event_name,
+                data,
+                is_event=True,
+            )
         else:
-            plot_item.items[0].setData(data)
+            scatter_item.setData(data)
 
     @property
     @property_params(
@@ -283,6 +563,17 @@ class EventsPlugin(neon_player.Plugin):
 
     @event_types.setter
     def event_types(self, value: list[EventType]) -> None:
+        unique_value = []
+        seen_names = set()
+        for et in value:
+            if et.name and et.name in seen_names:
+                continue
+            if et.name:
+                seen_names.add(et.name)
+            unique_value.append(et)
+
+        value = unique_value
+
         new_event_types = [
             event_type for event_type in value if event_type not in self._event_types
         ]
@@ -290,9 +581,14 @@ class EventsPlugin(neon_player.Plugin):
             event_type for event_type in self._event_types if event_type not in value
         ]
 
+        self._event_types = value
+
         for new_event_type in new_event_types:
             if new_event_type.uid == "":
                 new_event_type.uid = str(uuid.uuid4())
+
+            if new_event_type.uid not in self.events:
+                self.events[new_event_type.uid] = []
 
             event_type_counter = 1
             while new_event_type.name == "":
@@ -301,7 +597,7 @@ class EventsPlugin(neon_player.Plugin):
                     new_event_type.name = candidate_name
                 event_type_counter += 1
 
-            self._setup_gui_for_event_type(new_event_type)
+            self._update_all_timeline_data()
             new_event_type.changed.connect(self.changed.emit)
             new_event_type.name_changed.connect(
                 lambda old, new, et=new_event_type: self._on_event_name_changed(
@@ -309,33 +605,52 @@ class EventsPlugin(neon_player.Plugin):
                 )
             )
 
+        kept_uids = {et.uid for et in value}
         for removed_event_type in removed_event_types:
-            if removed_event_type.uid in self.events:
+            if (
+                removed_event_type.uid in self.events
+                and removed_event_type.uid not in kept_uids
+            ):
                 del self.events[removed_event_type.uid]
 
-            self.get_timeline().remove_timeline_plot(
-                f"Events - {removed_event_type.name}"
-            )
+            self.get_timeline().remove_timeline_plot(removed_event_type.name)
             self.save_cached_json("events.json", self.events)
             self.app.main_window.unregister_action(
                 f"Timeline/Add Event/{removed_event_type.name}"
             )
 
-        self._event_types = value
-
     def _on_event_name_changed(self, old_name, new_name, event_type) -> None:
-        self.get_timeline().remove_timeline_plot(f"Events - {old_name}")
-        self._update_timeline_data(event_type)
+        timeline = self.get_timeline()
+        plot = timeline.get_timeline_plot(old_name)
+        if plot:
+            timeline.timeline_plots[new_name] = timeline.timeline_plots.pop(old_name)
+            if old_name in timeline.timeline_legends:
+                timeline.timeline_legends[new_name] = timeline.timeline_legends.pop(
+                    old_name
+                )
 
-    def create_event_type(self, event_name: str) -> None:
+            if old_name in timeline.data_point_actions:
+                timeline.data_point_actions[new_name] = timeline.data_point_actions.pop(
+                    old_name
+                )
+
+            legend_container = timeline.timeline_legends[new_name].parentItem()
+            for item in legend_container.items:
+                if isinstance(item, pg.LabelItem):
+                    item.setText(new_name)
+                    break
+
+        self.app.main_window.unregister_action(f"Timeline/Add Event/{old_name}")
+        self._update_all_timeline_data()
+        timeline.sort_plots()
+        self.save_cached_json("events.json", self.events)
+
+    def create_event_type(self, event_name: str) -> EventType:
         event_type = EventType()
         event_type.uid = str(uuid.uuid4())
         event_type._name = event_name
 
-        if event_name in IMMUTABLE_EVENTS:
-            self._setup_gui_for_event_type(event_type)
-        else:
-            self.event_types = [*self._event_types, event_type]
+        self.event_types = [*self._event_types, event_type]
 
         return event_type
 

--- a/src/pupil_labs/neon_player/ui/settings_panel.py
+++ b/src/pupil_labs/neon_player/ui/settings_panel.py
@@ -1,5 +1,6 @@
 from datetime import datetime
 
+from pupil_labs.neon_recording import NeonRecording
 from PySide6.QtCore import Qt
 from PySide6.QtWidgets import (
     QHBoxLayout,
@@ -17,7 +18,6 @@ from qt_property_widgets.widgets import PropertyForm, PropertyWidget
 from pupil_labs import neon_player
 from pupil_labs.neon_player import Plugin
 from pupil_labs.neon_player.ui import ListPropertyAppenderAction
-from pupil_labs.neon_recording import NeonRecording
 
 
 class RecordingInfoWidget(QWidget):
@@ -146,7 +146,7 @@ class SettingsPanel(QScrollArea):
         expander = self.plugin_list_widget.add_expander(
             cls.get_label(), settings_form, not app.loading_recording
         )
-        if hasattr(instance, "header_action"):
+        if getattr(instance, "header_action", None) is not None:
             tb = QToolButton()
             tb.setText(instance.header_action.name)
             tb.setCursor(Qt.CursorShape.PointingHandCursor)

--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -11,6 +11,7 @@ from PySide6.QtCore import QPoint, QPointF, QSize, Qt, Signal
 from PySide6.QtGui import QColor, QCursor, QIcon, QKeyEvent
 from PySide6.QtWidgets import (
     QComboBox,
+    QGraphicsProxyWidget,
     QGraphicsSceneMouseEvent,
     QHBoxLayout,
     QMenu,
@@ -251,7 +252,9 @@ class TimeLineDock(QWidget):
 
             for item in plot_item.items:
                 if isinstance(item, pg.PlotDataItem):
-                    self._add_plot_data_item_tooltip(item, x, x_threshold, lines)
+                    self._add_plot_data_item_tooltip(
+                        item, x, x_threshold, lines, hovered_plot_name
+                    )
                 elif isinstance(item, pg.BarGraphItem):
                     self._add_bar_graph_item_tooltip(item, x, lines, hovered_plot_name)
 
@@ -274,7 +277,8 @@ class TimeLineDock(QWidget):
             for line in self.hover_lines.values():
                 line.setVisible(False)
 
-    def _add_plot_data_item_tooltip(self, item, x, x_threshold, lines):
+    def _add_plot_data_item_tooltip(self, item, x, x_threshold, lines, plot_name=""):
+        hovered_plot_name = plot_name
         x_data, y_data = item.getData()
         if x_data is not None and len(x_data) > 0 and y_data is not None:
             idx = np.searchsorted(x_data, x)
@@ -296,15 +300,58 @@ class TimeLineDock(QWidget):
                 if not name:
                     name = item.opts.get("name", "")
 
-                if isinstance(y_val, (float, np.floating)):
-                    val_str = f"{y_val:.4g}"
-                else:
-                    val_str = f"{y_val}"
+                is_event_plot = (
+                    hovered_plot_name and "Events" in hovered_plot_name
+                ) or getattr(item, "is_event", False)
 
-                if name:
-                    lines.append(f"<b>{name}:</b> {val_str}")
+                if not name and is_event_plot and hovered_plot_name:
+                    name = hovered_plot_name.replace("Events - ", "").replace(
+                        "00_Events", "Events"
+                    )
+
+                custom_names = getattr(item, "custom_names", None)
+                if custom_names and closest_idx < len(custom_names):
+                    name = custom_names[closest_idx]
+
+                if is_event_plot:
+                    app = neon_player.instance()
+                    time_ns = x_data[closest_idx]
+                    if app.recording:
+                        diff_ns = time_ns - app.recording.start_time
+
+                        total_ms = int(diff_ns // 1_000_000)
+                        ms = total_ms % 1000
+                        total_seconds = total_ms // 1000
+                        seconds = total_seconds % 60
+                        total_minutes = total_seconds // 60
+                        minutes = total_minutes % 60
+                        hours = total_minutes // 60
+
+                        val_str = f"{hours:02}:{minutes:02}:{seconds:02}.{ms:03}"
+                    else:
+                        val_str = str(time_ns)
+
+                    custom_reps = getattr(item, "custom_reps", None)
+                    if custom_reps and closest_idx < len(custom_reps):
+                        rep_str = custom_reps[closest_idx]
+                    else:
+                        total = len(x_data)
+                        rep_str = f" ({closest_idx + 1}/{total})" if total > 1 else ""
+
+                    if name:
+                        lines.append(f"<b>{name}{rep_str}</b><br/>{val_str}")
+                    else:
+                        lines.append(val_str)
                 else:
-                    lines.append(val_str)
+                    if isinstance(y_val, (float, np.floating)):
+                        val_str = f"{y_val:.4g}"
+                    else:
+                        val_str = f"{y_val}"
+
+                    if name:
+                        lines.append(f"<b>{name}:</b> {val_str}")
+                    else:
+                        lines.append(val_str)
 
     def _add_bar_graph_item_tooltip(self, item, x, lines, plot_name=""):
         opts = item.opts
@@ -531,7 +578,12 @@ class TimeLineDock(QWidget):
                 break
 
     def get_timeline_plot(
-        self, timeline_row_name: str, create_if_missing: bool = False, **kwargs
+        self,
+        timeline_row_name: str,
+        create_if_missing: bool = False,
+        legend_widget=None,
+        sort_name=None,
+        **kwargs,
     ) -> pg.PlotItem | None:
         if timeline_row_name in self.timeline_plots:
             return self.timeline_plots[timeline_row_name]
@@ -575,9 +627,16 @@ class TimeLineDock(QWidget):
         legend_container = pg.GraphicsLayout()
         legend_container.setSpacing(0)
         legend_container.setContentsMargins(0, 0, 0, 0)
-        legend_label = pg.LabelItem(timeline_row_name, justify="left")
 
-        legend_container.addItem(legend_label)
+        if legend_widget is not None:
+            proxy = QGraphicsProxyWidget()
+            proxy.setWidget(legend_widget)
+            proxy.sort_name = sort_name or timeline_row_name
+            legend_container.addItem(proxy)
+            legend_label = None
+        else:
+            legend_label = pg.LabelItem(timeline_row_name, justify="left")
+            legend_container.addItem(legend_label)
         legend_container.addItem(legend, row=1, col=0)
         legend_container.setSizePolicy(
             QSizePolicy.Policy.Ignored,
@@ -590,7 +649,8 @@ class TimeLineDock(QWidget):
         if is_timestamps_row:
             plot_item.preferred_height_1d = 50
             plot_item.adjust_size()
-            legend_label.anchor((0.5, 0), (0.5, 0), (0, 20))
+            if legend_label:
+                legend_label.anchor((0.5, 0), (0.5, 0), (0, 20))
 
         legend.layout.setSpacing(0)
         self.timeline_legends[timeline_row_name] = legend
@@ -662,7 +722,9 @@ class TimeLineDock(QWidget):
             return
 
         if color is None:
-            plot_index = len(plot_item.items)
+            plot_index = sum(
+                1 for item in plot_item.items if isinstance(item, pg.PlotDataItem)
+            )
             color = self.plot_colors[plot_index % len(self.plot_colors)]
 
         if "pen" not in kwargs:
@@ -674,9 +736,13 @@ class TimeLineDock(QWidget):
             plot_data_item = plot_item.plot(
                 data[:, 0], data[:, 1], name=plot_name, **kwargs
             )
-            plot_data_item.name = plot_name
-            if timeline_row_name in self.timeline_legends and plot_name != "":
-                legend.addItem(plot_data_item, plot_name)
+        else:
+            plot_data_item = plot_item.plot(x=[], y=[], name=plot_name, **kwargs)
+
+        plot_data_item.name = plot_name
+        plot_data_item.is_event = kwargs.get("is_event", False)
+        if timeline_row_name in self.timeline_legends and plot_name != "":
+            legend.addItem(plot_data_item, plot_name)
 
         self.sort_plots()
 
@@ -702,6 +768,8 @@ class TimeLineDock(QWidget):
             legend = self.timeline_legends[plot_name]
             self.graphics_layout.removeItem(legend.parentItem())
             del self.timeline_legends[plot_name]
+
+        self.unregister_data_point_actions(plot_name)
 
         self.sort_plots()
 
@@ -747,7 +815,7 @@ class TimeLineDock(QWidget):
         return self.add_timeline_plot(timeline_row_name, data, plot_name, **kwargs)
 
     def add_timeline_scatter(
-        self, name: str, data: list[tuple[int, int]], item_name: str = ""
+        self, name: str, data: list[tuple[int, int]], item_name: str = "", **kwargs
     ) -> pg.PlotDataItem:
         return self.add_timeline_plot(
             name,
@@ -755,7 +823,10 @@ class TimeLineDock(QWidget):
             item_name,
             pen=None,
             symbol="d",
-            symbolBrush=pg.mkColor("white"),
+            symbolSize=8,
+            symbolBrush=None,
+            symbolPen=pg.mkPen("#969696", width=3),
+            **kwargs,
         )
 
     def add_timeline_broken_bar(
@@ -839,7 +910,15 @@ class TimeLineDock(QWidget):
             else:
                 prefix = "20"
 
-            sort_key = f"{prefix}-{legend.rows[0][0].text.lower()}"
+            label_item = legend.rows[0][0]
+            if hasattr(label_item, "text") and isinstance(label_item.text, str):
+                text = label_item.text
+            elif hasattr(label_item, "text") and callable(label_item.text):
+                text = label_item.text()
+            else:
+                text = getattr(label_item, "sort_name", "z_unknown")
+
+            sort_key = f"{prefix}-{text.lower()}"
             items_to_move[sort_key] = (legend, plot)
 
             self.graphics_layout.removeItem(legend)
@@ -865,7 +944,15 @@ class TimeLineDock(QWidget):
         if row_name not in self.data_point_actions:
             self.data_point_actions[row_name] = []
 
+        for existing_name, _ in self.data_point_actions[row_name]:
+            if existing_name == action_name:
+                return
+
         self.data_point_actions[row_name].append((action_name, callback))
+
+    def unregister_data_point_actions(self, row_name: str) -> None:
+        if row_name in self.data_point_actions:
+            del self.data_point_actions[row_name]
 
     def reset_view(self):
         app = neon_player.instance()

--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -1,3 +1,4 @@
+import contextlib
 import logging
 import typing as T
 
@@ -269,13 +270,17 @@ class TimeLineDock(QWidget):
         if tooltip_text:
             QToolTip.showText(QCursor.pos(), tooltip_text)
 
-            for line in self.hover_lines.values():
-                line.setPos(x)
-                line.setVisible(True)
+            for line in list(self.hover_lines.values()):
+                try:
+                    line.setPos(x)
+                    line.setVisible(True)
+                except RuntimeError:
+                    pass
         else:
             QToolTip.hideText()
-            for line in self.hover_lines.values():
-                line.setVisible(False)
+            for line in list(self.hover_lines.values()):
+                with contextlib.suppress(RuntimeError):
+                    line.setVisible(False)
 
     def _add_plot_data_item_tooltip(self, item, x, x_threshold, lines, plot_name=""):
         hovered_plot_name = plot_name
@@ -817,6 +822,7 @@ class TimeLineDock(QWidget):
     def add_timeline_scatter(
         self, name: str, data: list[tuple[int, int]], item_name: str = "", **kwargs
     ) -> pg.PlotDataItem:
+        stroke_width = 3 if self.devicePixelRatio() > 1 else 1.5
         return self.add_timeline_plot(
             name,
             data,
@@ -825,7 +831,7 @@ class TimeLineDock(QWidget):
             symbol="d",
             symbolSize=8,
             symbolBrush=None,
-            symbolPen=pg.mkPen("#969696", width=3),
+            symbolPen=pg.mkPen("#969696", width=stroke_width),
             **kwargs,
         )
 


### PR DESCRIPTION
# PR: Events Timeline Fixes, Enhancements and UI Polish

## Overview
This PR address the recent bug introduced to the timeline events system where the hover line prevented drawing teh scatter points from events. It also enhances the Events plugin UI by introducing collapsible sections, real-time search, and refined visual aesthetics to mimic Cloud.

<details><summary>Changes by file (not complete)</summary>

### `src/pupil_labs/neon_player/plugins/events.py`

**1. Collapsible & Searchable UI**
- **Aggregate Row (`00_Events`)**: Added a top-level aggregate bar to visually summarize all event categories on a single row.
- **Toggle Mechanism**: Replaced the static header with a functional dropdown using standard Qt arrows (`Qt.ArrowType.DownArrow` / `RightArrow`) to expand and collapse the individual event rows.
- **Integrated Search (`01_Events_Search`)**: Added an inline search bar (`QLineEdit`) visible when the events section is expanded, enabling real-time filtering of event rows. Mapped the `Q` key for quick-focus.

**2. UI Polish**
- Styled the "Events" label and search box text with font size `13px` and color `#969696` to perfectly match other standard timeline items (like "Worn" and "Export window").

---

### `src/pupil_labs/neon_player/ui/timeline_dock.py`

**1. Bug Fixes (Tooltips & Registration Lifecycle)**
- **Intelligent Tooltips**: Rewrote the tooltip generator in `_add_plot_data_item_tooltip` to format timestamps as `HH:MM:SS.ms` instead of raw nanoseconds. It now correctly consumes injected `custom_names` and `custom_reps` metadata, allowing the aggregate row to show detailed information for clustered events.
- **Action Cleanup Pipeline**: Added `unregister_data_point_actions` to allow plugins to clear out stale context menu items. Hooked this cleanup directly into `remove_timeline_plot` to prevent endless duplication of "Seek" and "Delete" actions during UI refreshes or search filtering.
- **Defensive Registration**: Added strict uniqueness checks to block identical callback names from being appended repeatedly to `self.data_point_actions[row_name]`.

**2. UI Polish (Scatter Plot Markers)**
- Overhauled the default styling of event markers in `add_timeline_scatter` to make them less intrusive.
- Replaced the solid white circles with hollow diamond markers (`symbol="d"`, `symbolBrush=None`).
- Reduced the size to `8px` and thickened the stroke to `3px` using the new `#969696` color, giving the events a crisp, professional footprint on the timeline.

---

### `src/pupil_labs/neon_player/plugins/__init__.py`

- **Interface Support**: Added `unregister_data_point_actions(self, event_name: str)` to the base `Plugin` class to standardize how plugins manage their timeline context menus and prevent memory/action leaks.

---

### `src/pupil_labs/neon_player/ui/settings_panel.py`

**1. Bug Fixes (Crash Prevention)**
- Fixed an `AttributeError` caused during plugin loading. Switched from using `hasattr(instance, "header_action")` to explicitly checking `getattr(instance, "header_action", None) is not None`. This safely handles the case where a plugin sets its header action property to `None`, which previously caused the application to hard-crash on load. Essentially, caused by the addition of an empty row.

</details>


https://github.com/user-attachments/assets/b542f273-e47d-47a1-832b-5a369483e340

