### PR TITLE
fix(ui): align plugin menu to the right side of add/remove button

### DIFF
--- a/src/pupil_labs/neon_player/ui/settings_panel.py
+++ b/src/pupil_labs/neon_player/ui/settings_panel.py
@@ -1,6 +1,6 @@
 from datetime import datetime
 
-from PySide6.QtCore import Qt
+from PySide6.QtCore import Qt, QPoint
 from PySide6.QtWidgets import (
     QHBoxLayout,
     QLabel,
@@ -91,7 +91,10 @@ class PluginManagerWidget(QWidget):
         action.setDefaultWidget(form)
         menu.addAction(action)
 
-        menu.exec(self.button.mapToGlobal(self.button.rect().bottomLeft()))
+        # Align the right sides of the menu (i.e., checkboxes) and button
+        bottom_right_corner = self.button.mapToGlobal(self.button.rect().bottomRight())
+        menu_width_offset = QPoint(menu.sizeHint().width() - 10, 0)
+        menu.exec(bottom_right_corner - menu_width_offset)
 
 
 class SettingsPanel(QScrollArea):


### PR DESCRIPTION
This PR targets a minor problem that I encountered on Ubuntu with display scaling enabled: the checkboxes in the plugin menu ("Add/Remove") may appear out of screen if the window is maximized.

<img width="793" height="756" alt="Screenshot from 2026-04-10 10-58-18" src="https://github.com/user-attachments/assets/2f257df7-1f83-405e-a60f-6a14ea735637" />

This issue seems to appear in other Qt-based apps as well, but if we align the pop-up menu to the right corner of the Add/Remove button, at least the checkboxes are guaranteed to stay within the area of the main window. This PR does exactly that, see the result below:

<img width="791" height="1126" alt="Screenshot from 2026-04-10 11-42-01" src="https://github.com/user-attachments/assets/9178210d-29fb-49dc-ba3e-293d6df247aa" />