### PR TITLE
fix(fixations): handle cases when no gaze samples correspond to a fixation

### DIFF
--- a/src/pupil_labs/neon_player/plugins/fixations.py
+++ b/src/pupil_labs/neon_player/plugins/fixations.py
@@ -277,6 +277,9 @@ class FixationsPlugin(neon_player.Plugin):
                 (fixation.start_time <= gaze.time) & (gaze.time <= fixation.stop_time)
             ]
 
+            if not gaze_samples.size:
+                continue
+
             ref_gaze = gaze_samples[len(gaze_samples) // 2]
 
             start_scene_idx, stop_scene_idx = np.searchsorted(

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
@@ -513,6 +513,7 @@ class TrackedSurface(PersistentPropertiesMixin, QObject):
             fixation_gazes = gazes[start_mask & end_mask]
 
             if not fixation_gazes.size:
+                fixations_on_surfs.append(0)
                 continue
 
             mapped_gazes = self.apply_offset_and_map_gazes(fixation_gazes)

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
@@ -512,6 +512,9 @@ class TrackedSurface(PersistentPropertiesMixin, QObject):
             end_mask = gazes.time <= fixation[1]["end timestamp [ns]"]
             fixation_gazes = gazes[start_mask & end_mask]
 
+            if not fixation_gazes.size:
+                continue
+
             mapped_gazes = self.apply_offset_and_map_gazes(fixation_gazes)
 
             lower_pass = np.all(mapped_gazes >= 0, axis=1)


### PR DESCRIPTION
Currently, this happens in two contexts, leading to an error. Fixes implemented:
* calculation of optic flow - the fixation is skipped now
* surface export - the fixation is kept in the export, `fixation detected on surface` is now set to 0