### PR TITLE
fix: slow loading of recordings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
     "protobuf<6",
     "pupil-apriltags>=1.0.4.post11",
     "pupil-labs-marker-mapper>=1.0.0",
-    "pupil-labs-neon-recording>=2.1.2",
+    "pupil-labs-neon-recording>=2.1.4",
     "pupil-labs-video>=1.0.11",
     "pyobjc; sys_platform == 'darwin'",
     "pyqtgraph>=0.13.7",


### PR DESCRIPTION
pl-neon-recording v2.1.2 had a performance issue causing long recs to take a long time to load