### PR TITLE
fix(surface_tracking): correctly display the tracked surface and mapped gazes in the dedicated view

### DIFF
--- a/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
@@ -808,6 +808,7 @@ class SurfaceTrackingPlugin(Plugin):
             pickle.dump(surface.tracker_surface, f)
 
         surface._heatmap = None
+        surface.preview_options.render_size = [0, 0]
         self.trigger_scene_update()
 
         self._start_bg_surface_locator(surface)

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
@@ -70,12 +70,11 @@ class SurfaceViewDisplayOptions(PersistentPropertiesMixin, QObject):
         self._render_size = [0, 0]
 
     @property
-    @property_params(prevent_add=True)
+    @property_params(widget=None)
     def render_size(self) -> list[int]:
         return self._render_size
 
     @render_size.setter
-    @property_params(widget=None)
     def render_size(self, value: list[int]) -> None:
         self._render_size = value
         self.changed.emit()

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
@@ -566,7 +566,8 @@ class TrackedSurface(PersistentPropertiesMixin, QObject):
         painter.drawImage(0, 0, qimage_from_frame(surface_image))
 
         gazes = gaze_plugin.get_gazes_for_scene(scene_idx).point
-        gazes = camera.undistort_points(gazes)
+        if len(gazes) > 0:
+            gazes = camera.undistort_points(gazes)
 
         mapped_gazes = self.image_points_to_surface(gazes)
         mapped_gazes[:, 0] *= self.preview_options.render_size[0]

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
@@ -70,6 +70,7 @@ class SurfaceViewDisplayOptions(PersistentPropertiesMixin, QObject):
         self._render_size = [0, 0]
 
     @property
+    @property_params(prevent_add=True)
     def render_size(self) -> list[int]:
         return self._render_size
 
@@ -566,6 +567,7 @@ class TrackedSurface(PersistentPropertiesMixin, QObject):
         painter.drawImage(0, 0, qimage_from_frame(surface_image))
 
         gazes = gaze_plugin.get_gazes_for_scene(scene_idx).point
+        gazes = camera.undistort_points(gazes)
 
         mapped_gazes = self.image_points_to_surface(gazes)
         mapped_gazes[:, 0] *= self.preview_options.render_size[0]


### PR DESCRIPTION
* render size is reset and recalculated on every adjustment to the tracked surface
* gaze points are undistorted before displaying on top of the surface image