### PR TITLE
fix(events): remove data point actions on plugin disable or event type removal

### DIFF
--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -63,6 +63,13 @@ class Plugin(PersistentPropertiesMixin, QObject):
             event_name, action_name, callback
         )
 
+    def unregister_data_point_action(
+        self, event_name: str, action_name: str
+    ):
+        self.app.main_window.timeline.unregister_data_point_action(
+            event_name, action_name
+        )
+
     def add_dynamic_action(self, name: str, func: T.Callable) -> None:
         my_prop_form = self.app.main_window.settings_panel.plugin_class_expanders[
             self.__class__.__name__

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -175,10 +175,7 @@ class EventsPlugin(neon_player.Plugin):
         timeline = self.get_timeline()
         timeline.remove_timeline_plot("Events")
         for et in self._event_types:
-            timeline.remove_timeline_plot(f"Events - {et.name}")
-
-        for plot_name in IMMUTABLE_EVENTS:
-            timeline.remove_timeline_plot(f"Events - {plot_name}")
+            self._remove_gui_for_event_name(et.name)
 
     def _setup_gui_for_event_type(self, event_type: EventType) -> None:
         timeline = self.get_timeline()
@@ -216,6 +213,27 @@ class EventsPlugin(neon_player.Plugin):
 
         register_data_actions()
         event_type.name_changed.connect(lambda _, _2: register_data_actions())
+
+    def _remove_gui_for_event_name(
+        self,
+        event_name: str,
+        remove_add_action: bool = True
+    ) -> None:
+        timeline = self.get_timeline()
+        timeline.remove_timeline_plot(f"Events - {event_name}")
+        timeline.unregister_data_point_action(
+            f"Events - {event_name}", f"Seek to this {event_name}"
+        )
+
+        if event_name in IMMUTABLE_EVENTS:
+            return
+
+        timeline.unregister_data_point_action(
+            f"Events - {event_name}", f"Delete {event_name} instance"
+        )
+        if remove_add_action:
+            self.unregister_timeline_action(f"Add Event/{event_name}")
+            self.app.main_window.remove_menu_if_empty("Timeline/Add Event")
 
     def add_event(self, event_type: EventType, ts: int | None = None) -> None:
         if self.recording is None:
@@ -313,18 +331,13 @@ class EventsPlugin(neon_player.Plugin):
             if removed_event_type.uid in self.events:
                 del self.events[removed_event_type.uid]
 
-            self.get_timeline().remove_timeline_plot(
-                f"Events - {removed_event_type.name}"
-            )
+            self._remove_gui_for_event_name(removed_event_type.name)
             self.save_cached_json("events.json", self.events)
-            self.app.main_window.unregister_action(
-                f"Timeline/Add Event/{removed_event_type.name}"
-            )
 
         self._event_types = value
 
     def _on_event_name_changed(self, old_name, new_name, event_type) -> None:
-        self.get_timeline().remove_timeline_plot(f"Events - {old_name}")
+        self._remove_gui_for_event_name(old_name, remove_add_action=False)
         self._update_timeline_data(event_type)
 
     def create_event_type(self, event_name: str) -> None:

--- a/src/pupil_labs/neon_player/ui/main_window.py
+++ b/src/pupil_labs/neon_player/ui/main_window.py
@@ -666,6 +666,21 @@ class MainWindow(QMainWindow):
 
         return menu
 
+    def remove_menu_if_empty(self, menu_path: str) -> None:
+        menu = self.get_menu(menu_path, auto_create=False)
+        if menu is None or len(menu.actions()) > 0:
+            return
+
+        parent_menu_path, _, action_name = menu_path.rpartition("/")
+        parent_menu = self.get_menu(parent_menu_path, auto_create=False)
+        if parent_menu is None:
+            return
+
+        for action in parent_menu.actions():
+            if action.text().replace("&", "") == action_name.replace("&", ""):
+                parent_menu.removeAction(action)
+                break
+
     def get_action(self, action_path: str) -> QAction:
         menu_path, action_name = action_path.rsplit("/", 1)
         menu = self.get_menu(menu_path)

--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -583,7 +583,7 @@ class TimeLineDock(QWidget):
 
         context_menu = QMenu()
 
-        for action_name, callback in self.data_point_actions[timeline_name]:
+        for action_name, callback in self.data_point_actions[timeline_name].items():
             action = context_menu.addAction(action_name)
             action.triggered.connect(lambda _, cb=callback: cb(data_point))
 
@@ -708,9 +708,20 @@ class TimeLineDock(QWidget):
         self, row_name: str, action_name: str, callback: T.Callable
     ) -> None:
         if row_name not in self.data_point_actions:
-            self.data_point_actions[row_name] = []
+            self.data_point_actions[row_name] = {}
 
-        self.data_point_actions[row_name].append((action_name, callback))
+        self.data_point_actions[row_name][action_name] = callback
+
+    def unregister_data_point_action(
+        self, row_name: str, action_name: str
+    ) -> None:
+        if row_name not in self.data_point_actions:
+            return
+
+        if action_name not in self.data_point_actions[row_name]:
+            return
+
+        del self.data_point_actions[row_name][action_name]
 
     def reset_view(self):
         app = neon_player.instance()


### PR DESCRIPTION
* Internally, changed `TimeLineDock.data_point_actions` to be a nested dictionary (row name -> action name), which enables fast removal of data point actions
* Also added a function to prune menus if all actions were removed - using it to remove Timeline/Add event if all event types are deleted
* Finally, made the removal of GUI elements for an event type consistent across occasions when it is required