### PR TITLE
feat: introduce property scopes and shared workspace-scope settings

### DIFF
--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -185,37 +185,58 @@ class NeonPlayerApp(QApplication):
 
         self.quit()
 
-    def load_global_settings(self) -> T.Any:
-        settings_path = Path.home() / "Pupil Labs" / "Neon Player" / "settings.json"
-        logging.info(f"Loading settings from {settings_path}")
-        return json.loads(settings_path.read_text())
+    @property
+    def history_path(self) -> Path:
+        return Path.home() / "Pupil Labs" / "Neon Player" / "history.json"
 
-    def load_recording_history(self) -> T.Any:
-        history_path = Path.home() / "Pupil Labs" / "Neon Player" / "history.json"
-        logging.info(f"Loading recording history from {history_path}")
-        return json.loads(history_path.read_text())
+    @property
+    def settings_path(self) -> Path:
+        return Path.home() / "Pupil Labs" / "Neon Player" / "settings.json"
 
     @property
     def recording_settings_path(self) -> Path | None:
         if self.recording is None:
             return None
 
-        return self.recording._rec_dir / ".neon_player" / "settings.json"
+        if not self.batch_mode_enabled:
+            return self.recording._rec_dir / ".neon_player" / "settings.json"
+
+        recording_name = self.recording._rec_dir.name
+        return self.workspace.path / ".neon_player" / "cache" / recording_name / "settings.json"
+
+    @property
+    def workspace_settings_path(self) -> Path | None:
+        if self.workspace.path is None:
+            return None
+
+        return self.workspace.path / ".neon_player" / "settings.json"
+
+    def load_global_settings(self) -> T.Any:
+        logging.info(f"Loading settings from {self.settings_path}")
+        return json.loads(self.settings_path.read_text())
+
+    def load_recording_history(self) -> T.Any:
+        logging.info(f"Loading recording history from {self.history_path}")
+        return json.loads(self.history_path.read_text())
 
     def save_settings(self) -> None:
         if self._initializing:
             return
 
         try:
-            settings_path = Path.home() / "Pupil Labs" / "Neon Player" / "settings.json"
-            settings_path.parent.mkdir(parents=True, exist_ok=True)
+            self.settings_path.parent.mkdir(parents=True, exist_ok=True)
             data = self.settings.to_dict()
-            with settings_path.open("w") as f:
+            with self.settings_path.open("w") as f:
                 json.dump(data, f, cls=ComplexEncoder)
 
             if self.recording:
                 self.plugin_settings.save_recording_settings(
                     self.recording_settings_path
+                )
+
+            if self.batch_mode_enabled:
+                self.plugin_settings.save_workspace_settings(
+                    self.workspace_settings_path
                 )
 
             logging.info("Settings saved")
@@ -225,10 +246,9 @@ class NeonPlayerApp(QApplication):
 
     def save_history(self) -> None:
         try:
-            history_path = Path.home() / "Pupil Labs" / "Neon Player" / "history.json"
-            history_path.parent.mkdir(parents=True, exist_ok=True)
+            self.history_path.parent.mkdir(parents=True, exist_ok=True)
             data = self.recording_history.recent_recordings
-            with history_path.open("w") as f:
+            with self.history_path.open("w") as f:
                 json.dump(data, f, cls=ComplexEncoder)
 
             logging.info("History saved")
@@ -386,6 +406,7 @@ class NeonPlayerApp(QApplication):
             # Only include this recording in the workspace
             recording_path = path
             self.workspace.add_recording(recording_path)
+            self.plugin_settings.set_batch_mode(False)
         else:
             # Load all recordings that appear as first-level subfolders
             self.workspace.load_recording_list(path)
@@ -398,7 +419,12 @@ class NeonPlayerApp(QApplication):
                     "select a different folder."
                 )
                 return
+
             recording_path = self.workspace.recordings[0]._rec_dir
+            self.plugin_settings.set_batch_mode(True)
+            self.plugin_settings.load_workspace_settings(
+                self.workspace_settings_path
+            )
 
         self.workspace_loaded.emit()
         self.load_recording(recording_path)
@@ -436,6 +462,10 @@ class NeonPlayerApp(QApplication):
         logging.info(f"Loaded `{self.recording._rec_dir}`")
 
     def toggle_plugins_by_settings(self) -> None:
+        print(f"Recording settings: {self.plugin_settings.recording_settings.enabled_plugins}")
+        print(f"Workspace settings: {self.plugin_settings.workspace_settings.enabled_plugins}")
+        print(f"Plugin settings: {self.plugin_settings.enabled_plugins}")
+
         for cls_name, enabled in self.plugin_settings.enabled_plugins.items():
             state = self.plugin_settings.plugin_states.get(cls_name, {})
             self.toggle_plugin(cls_name, enabled, state)

--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -401,12 +401,12 @@ class NeonPlayerApp(QApplication):
         self.unload()
         is_neon_recording = check_if_neon_recording(path)
         self.batch_mode_enabled = not is_neon_recording
+        self.plugin_settings.batch_mode_enabled = self.batch_mode_enabled
 
         if is_neon_recording:
             # Only include this recording in the workspace
             recording_path = path
             self.workspace.add_recording(recording_path)
-            self.plugin_settings.set_batch_mode(False)
         else:
             # Load all recordings that appear as first-level subfolders
             self.workspace.load_recording_list(path)
@@ -421,7 +421,6 @@ class NeonPlayerApp(QApplication):
                 return
 
             recording_path = self.workspace.recordings[0]._rec_dir
-            self.plugin_settings.set_batch_mode(True)
             self.plugin_settings.load_workspace_settings(
                 self.workspace_settings_path
             )

--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -44,7 +44,9 @@ from pupil_labs.neon_player.plugins import (
     video_exporter,  # noqa: F401
 )
 from pupil_labs.neon_player.history import RecordingHistory
-from pupil_labs.neon_player.settings import GeneralSettings, RecordingSettings
+from pupil_labs.neon_player.settings import (
+    GeneralSettings, PluginSettingsDispatcher
+)
 from pupil_labs.neon_player.ui.main_window import MainWindow
 from pupil_labs.neon_player.ui.plugin_installation_dialog import (
     PluginInstallationDialog,
@@ -92,7 +94,7 @@ class NeonPlayerApp(QApplication):
 
         self.settings = GeneralSettings()
         self.loading_recording = False
-        self.recording_settings = None
+        self.plugin_settings = PluginSettingsDispatcher()
         self.recording_history = RecordingHistory()
 
         self.refresh_timer = QTimer(self)
@@ -193,6 +195,13 @@ class NeonPlayerApp(QApplication):
         logging.info(f"Loading recording history from {history_path}")
         return json.loads(history_path.read_text())
 
+    @property
+    def recording_settings_path(self) -> Path | None:
+        if self.recording is None:
+            return None
+
+        return self.recording._rec_dir / ".neon_player" / "settings.json"
+
     def save_settings(self) -> None:
         if self._initializing:
             return
@@ -205,13 +214,9 @@ class NeonPlayerApp(QApplication):
                 json.dump(data, f, cls=ComplexEncoder)
 
             if self.recording:
-                settings_path = (
-                    self.recording._rec_dir / ".neon_player" / "settings.json"
+                self.plugin_settings.save_recording_settings(
+                    self.recording_settings_path
                 )
-                settings_path.parent.mkdir(parents=True, exist_ok=True)
-                data = self.recording_settings.to_dict()
-                with settings_path.open("w") as f:
-                    json.dump(data, f, cls=ComplexEncoder)
 
             logging.info("Settings saved")
         except Exception:
@@ -288,7 +293,7 @@ class NeonPlayerApp(QApplication):
             logging.info(f"Enabling plugin: {kls.__name__}")
             try:
                 if state is None:
-                    state = self.recording_settings.plugin_states.get(kls.__name__, {})
+                    state = self.plugin_settings.plugin_states.get(kls.__name__, {})
 
                 plugin: Plugin = kls.from_dict(state)
 
@@ -411,35 +416,8 @@ class NeonPlayerApp(QApplication):
         self.playback_start_anchor = 0
 
         self.main_window.on_recording_loaded(self.recording)
-
-        try:
-            settings_path = path / ".neon_player" / "settings.json"
-            if settings_path.exists():
-                logging.info(f"Loading recording settings from {settings_path}")
-                self.recording_settings = RecordingSettings.from_dict(
-                    json.loads(settings_path.read_text())
-                )
-
-                if len(self.recording_settings.export_window) != 2:
-                    logging.warning("Invalid export window in settings")
-                    self.recording_settings.export_window = [
-                        self.recording.start_time,
-                        self.recording.stop_time,
-                    ]
-
-            else:
-                self.recording_settings = RecordingSettings()
-                self.recording_settings.export_window = [
-                    self.recording.start_time,
-                    self.recording.stop_time,
-                ]
-
-        except Exception:
-            logging.exception("Failed to load settings")
-            self.recording_settings = RecordingSettings()
-
-        logging.info(
-            "Recording settings loaded", self.recording_settings.enabled_plugins
+        self.plugin_settings.load_recording_settings(
+            self.recording_settings_path, self.recording
         )
 
         if self.settings.skip_gray_frames_on_load:
@@ -449,8 +427,8 @@ class NeonPlayerApp(QApplication):
 
         QTimer.singleShot(0, self.toggle_plugins_by_settings)
         QTimer.singleShot(10, self.on_recording_load_complete)
-        self.recording_settings.changed.connect(self.toggle_plugins_by_settings)
-        SlotDebouncer.debounce(self.recording_settings.changed, self.save_settings)
+        self.plugin_settings.changed.connect(self.toggle_plugins_by_settings)
+        SlotDebouncer.debounce(self.plugin_settings.changed, self.save_settings)
 
     def on_recording_load_complete(self) -> None:
         self.loading_recording = False
@@ -458,8 +436,8 @@ class NeonPlayerApp(QApplication):
         logging.info(f"Loaded `{self.recording._rec_dir}`")
 
     def toggle_plugins_by_settings(self) -> None:
-        for cls_name, enabled in self.recording_settings.enabled_plugins.items():
-            state = self.recording_settings.plugin_states.get(cls_name, {})
+        for cls_name, enabled in self.plugin_settings.enabled_plugins.items():
+            state = self.plugin_settings.plugin_states.get(cls_name, {})
             self.toggle_plugin(cls_name, enabled, state)
 
         self._initializing = False

--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -94,7 +94,6 @@ class NeonPlayerApp(QApplication):
 
         self.settings = GeneralSettings()
         self.loading_recording = False
-        self.plugin_settings = PluginSettingsDispatcher()
         self.recording_history = RecordingHistory()
 
         self.refresh_timer = QTimer(self)
@@ -133,6 +132,10 @@ class NeonPlayerApp(QApplication):
         plugin_search_path = Path.home() / "Pupil Labs" / "Neon Player" / "plugins"
         if plugin_search_path.exists():
             self.find_plugins(plugin_search_path)
+
+        # NOTE: plugins should be loaded before initializing the dispatcher
+        # to ensure that property scopes are collected correctly
+        self.plugin_settings = PluginSettingsDispatcher()
 
         try:
             self.settings = GeneralSettings.from_dict(self.load_global_settings())
@@ -381,6 +384,8 @@ class NeonPlayerApp(QApplication):
 
     def unload_recording(self) -> None:
         self.set_playback_state(False)
+        self.save_settings()
+
         class_names = list(self.plugins_by_class.keys())
         for plugin_class_name in class_names:
             self.toggle_plugin(plugin_class_name, False)

--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -105,6 +105,7 @@ class NeonPlayerApp(QApplication):
 
         parser = argparse.ArgumentParser()
         parser.add_argument("recording", nargs="?", default=None, help="")
+        parser.add_argument("--workspace", action="store_true")
         parser.add_argument("--progress-ipc-name", type=str, default=None)
         parser.add_argument(
             "--job",
@@ -157,7 +158,14 @@ class NeonPlayerApp(QApplication):
         self.recording_history.changed.connect(self.save_history)
 
         if self.args.job and self.args.recording:
-            self.load(Path(self.args.recording))
+            path_to_load = Path(self.args.recording)
+            if self.args.workspace:
+                self.set_batch_mode(True)
+                self.load_workspace(path_to_load.parent)
+                self.workspace_loaded.emit()
+                self.load_recording(path_to_load)
+            else:
+                self.load(path_to_load)
         elif self.args.recording:
             QTimer.singleShot(1, lambda: self.load(Path(self.args.recording)))
         else:
@@ -405,8 +413,7 @@ class NeonPlayerApp(QApplication):
         """
         self.unload()
         is_neon_recording = check_if_neon_recording(path)
-        self.batch_mode_enabled = not is_neon_recording
-        self.session_settings.batch_mode_enabled = self.batch_mode_enabled
+        self.set_batch_mode(not is_neon_recording)
 
         if is_neon_recording:
             # Only include this recording in the workspace
@@ -414,8 +421,8 @@ class NeonPlayerApp(QApplication):
             self.workspace.add_recording(recording_path)
         else:
             # Load all recordings that appear as first-level subfolders
-            self.workspace.load_recording_list(path)
-            if not self.workspace.num_recordings:
+            self.load_workspace(path)
+            if not self.workspace.recordings:
                 QMessageBox.critical(
                     self.main_window,
                     "No recordings found!",
@@ -426,12 +433,19 @@ class NeonPlayerApp(QApplication):
                 return
 
             recording_path = self.workspace.recordings[0]._rec_dir
-            self.session_settings.load_workspace_settings(
-                self.workspace_settings_path
-            )
 
         self.workspace_loaded.emit()
         self.load_recording(recording_path)
+
+    def set_batch_mode(self, enabled: bool) -> None:
+        self.batch_mode_enabled = enabled
+        self.session_settings.batch_mode_enabled = enabled
+
+    def load_workspace(self, path: Path) -> None:
+        self.workspace.load_recording_list(path)
+        self.session_settings.load_workspace_settings(
+            self.workspace_settings_path
+        )
 
     def load_recording(self, path: Path) -> None:
         """Load a recording from the given path."""

--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -198,18 +198,14 @@ class NeonPlayerApp(QApplication):
         if self.recording is None:
             return None
 
-        if not self.batch_mode_enabled:
-            return self.recording._rec_dir / ".neon_player" / "settings.json"
-
-        recording_name = self.recording._rec_dir.name
-        return self.workspace.path / ".neon_player" / "cache" / recording_name / "settings.json"
+        return self.recording._rec_dir / ".neon_player" / "settings.json"
 
     @property
     def workspace_settings_path(self) -> Path | None:
         if self.workspace.path is None:
             return None
 
-        return self.workspace.path / ".neon_player" / "settings.json"
+        return self.workspace.path / ".neon_player" / "workspace-settings.json"
 
     def load_global_settings(self) -> T.Any:
         logging.info(f"Loading settings from {self.settings_path}")

--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -56,6 +56,7 @@ from pupil_labs.neon_player.workspace import Workspace, check_if_neon_recording
 
 
 class NeonPlayerApp(QApplication):
+    export_window_changed = Signal()
     playback_state_changed = Signal(bool)
     position_changed = Signal(object)
     seeked = Signal(object)
@@ -135,7 +136,10 @@ class NeonPlayerApp(QApplication):
 
         # NOTE: plugins should be loaded before initializing the dispatcher
         # to ensure that property scopes are collected correctly
-        self.plugin_settings = PluginSettingsDispatcher()
+        self.session_settings = PluginSettingsDispatcher()
+        self.session_settings.export_window_changed.connect(
+            self.export_window_changed.emit
+        )
 
         try:
             self.settings = GeneralSettings.from_dict(self.load_global_settings())
@@ -229,12 +233,12 @@ class NeonPlayerApp(QApplication):
                 json.dump(data, f, cls=ComplexEncoder)
 
             if self.recording:
-                self.plugin_settings.save_recording_settings(
+                self.session_settings.save_recording_settings(
                     self.recording_settings_path
                 )
 
             if self.batch_mode_enabled:
-                self.plugin_settings.save_workspace_settings(
+                self.session_settings.save_workspace_settings(
                     self.workspace_settings_path
                 )
 
@@ -312,7 +316,7 @@ class NeonPlayerApp(QApplication):
             logging.info(f"Enabling plugin: {kls.__name__}")
             try:
                 if state is None:
-                    state = self.plugin_settings.plugin_states.get(kls.__name__, {})
+                    state = self.session_settings.plugin_states.get(kls.__name__, {})
 
                 plugin: Plugin = kls.from_dict(state)
 
@@ -402,7 +406,7 @@ class NeonPlayerApp(QApplication):
         self.unload()
         is_neon_recording = check_if_neon_recording(path)
         self.batch_mode_enabled = not is_neon_recording
-        self.plugin_settings.batch_mode_enabled = self.batch_mode_enabled
+        self.session_settings.batch_mode_enabled = self.batch_mode_enabled
 
         if is_neon_recording:
             # Only include this recording in the workspace
@@ -422,7 +426,7 @@ class NeonPlayerApp(QApplication):
                 return
 
             recording_path = self.workspace.recordings[0]._rec_dir
-            self.plugin_settings.load_workspace_settings(
+            self.session_settings.load_workspace_settings(
                 self.workspace_settings_path
             )
 
@@ -442,7 +446,7 @@ class NeonPlayerApp(QApplication):
         self.playback_start_anchor = 0
 
         self.main_window.on_recording_loaded(self.recording)
-        self.plugin_settings.load_recording_settings(
+        self.session_settings.load_recording_settings(
             self.recording_settings_path, self.recording
         )
 
@@ -453,8 +457,8 @@ class NeonPlayerApp(QApplication):
 
         QTimer.singleShot(0, self.toggle_plugins_by_settings)
         QTimer.singleShot(10, self.on_recording_load_complete)
-        self.plugin_settings.changed.connect(self.toggle_plugins_by_settings)
-        SlotDebouncer.debounce(self.plugin_settings.changed, self.save_settings)
+        self.session_settings.changed.connect(self.toggle_plugins_by_settings)
+        SlotDebouncer.debounce(self.session_settings.changed, self.save_settings)
 
     def on_recording_load_complete(self) -> None:
         self.loading_recording = False
@@ -462,12 +466,8 @@ class NeonPlayerApp(QApplication):
         logging.info(f"Loaded `{self.recording._rec_dir}`")
 
     def toggle_plugins_by_settings(self) -> None:
-        print(f"Recording settings: {self.plugin_settings.recording_settings.enabled_plugins}")
-        print(f"Workspace settings: {self.plugin_settings.workspace_settings.enabled_plugins}")
-        print(f"Plugin settings: {self.plugin_settings.enabled_plugins}")
-
-        for cls_name, enabled in self.plugin_settings.enabled_plugins.items():
-            state = self.plugin_settings.plugin_states.get(cls_name, {})
+        for cls_name, enabled in self.session_settings.enabled_plugins.items():
+            state = self.session_settings.plugin_states.get(cls_name, {})
             self.toggle_plugin(cls_name, enabled, state)
 
         self._initializing = False

--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -141,6 +141,8 @@ class NeonPlayerApp(QApplication):
         self.session_settings.export_window_changed.connect(
             self.export_window_changed.emit
         )
+        self.session_settings.changed.connect(self.toggle_plugins_by_settings)
+        SlotDebouncer.debounce(self.session_settings.changed, self.save_settings)
 
         try:
             self.settings = GeneralSettings.from_dict(self.load_global_settings())
@@ -471,8 +473,6 @@ class NeonPlayerApp(QApplication):
 
         QTimer.singleShot(0, self.toggle_plugins_by_settings)
         QTimer.singleShot(10, self.on_recording_load_complete)
-        self.session_settings.changed.connect(self.toggle_plugins_by_settings)
-        SlotDebouncer.debounce(self.session_settings.changed, self.save_settings)
 
     def on_recording_load_complete(self) -> None:
         self.loading_recording = False

--- a/src/pupil_labs/neon_player/job_manager.py
+++ b/src/pupil_labs/neon_player/job_manager.py
@@ -53,7 +53,16 @@ class BackgroundJob(QObject):
         args = [
             str(recording_path),
             "--progress-ipc-name",
-            server_name,
+            server_name
+        ]
+
+        # When batch mode is enabled, let the subprocess know that the job
+        # needs to be executed with a workspace (i.e., parent folder) in mind
+        app = neon_player.instance()
+        if app.batch_mode_enabled:
+            args += ["--workspace"]
+
+        args += [
             "--job",
             action_name,
         ] + [str(arg) for arg in args]

--- a/src/pupil_labs/neon_player/job_manager.py
+++ b/src/pupil_labs/neon_player/job_manager.py
@@ -20,6 +20,40 @@ class ProgressUpdate:
     datum: T.Any = None
 
 
+def prepare_command(
+    recording_path: Path, 
+    action_name: str,
+    args: T.Any,
+    server_name: str,
+    batch_mode_enabled: bool,
+    is_frozen: bool,
+):
+    """
+    Prepares the command line call for running a background job in a subprocess.
+    """
+    
+    cmd_args = [
+        str(recording_path),
+        "--progress-ipc-name",
+        server_name
+    ]
+
+    # When batch mode is enabled, let the subprocess know that the job
+    # needs to be executed with a workspace (i.e., parent folder) in mind
+    if batch_mode_enabled:
+        cmd_args += ["--workspace"]
+
+    cmd_args += [
+        "--job",
+        action_name,
+    ] + [str(arg) for arg in args]
+
+    if is_frozen:
+        return [sys.executable, *cmd_args]
+    
+    return [sys.executable, "-m", "pupil_labs.neon_player", *cmd_args]
+
+
 class BackgroundJob(QObject):
     progress_changed = Signal(float)
     finished = Signal()
@@ -50,28 +84,14 @@ class BackgroundJob(QObject):
 
         self.server.newConnection.connect(self._handle_connection)
 
-        cmd_args = [
-            str(recording_path),
-            "--progress-ipc-name",
-            server_name
-        ]
-
-        # When batch mode is enabled, let the subprocess know that the job
-        # needs to be executed with a workspace (i.e., parent folder) in mind
-        app = neon_player.instance()
-        if app.batch_mode_enabled:
-            cmd_args += ["--workspace"]
-
-        cmd_args += [
-            "--job",
-            action_name,
-        ] + [str(arg) for arg in args]
-
-        if neon_player.is_frozen():
-            cmd = [sys.executable, *cmd_args]
-        else:
-            cmd = [sys.executable, "-m", "pupil_labs.neon_player", *cmd_args]
-
+        cmd = prepare_command(
+            recording_path=recording_path,
+            action_name=action_name,
+            args=args,
+            server_name=server_name,
+            batch_mode_enabled=neon_player.instance().batch_mode_enabled,
+            is_frozen=neon_player.is_frozen(),
+        )
         logging.debug(f"Executing bg job {' '.join(cmd)}")
 
         self.proc = subprocess.Popen(cmd)  # noqa: S603

--- a/src/pupil_labs/neon_player/job_manager.py
+++ b/src/pupil_labs/neon_player/job_manager.py
@@ -50,7 +50,7 @@ class BackgroundJob(QObject):
 
         self.server.newConnection.connect(self._handle_connection)
 
-        args = [
+        cmd_args = [
             str(recording_path),
             "--progress-ipc-name",
             server_name
@@ -60,17 +60,17 @@ class BackgroundJob(QObject):
         # needs to be executed with a workspace (i.e., parent folder) in mind
         app = neon_player.instance()
         if app.batch_mode_enabled:
-            args += ["--workspace"]
+            cmd_args += ["--workspace"]
 
-        args += [
+        cmd_args += [
             "--job",
             action_name,
         ] + [str(arg) for arg in args]
 
         if neon_player.is_frozen():
-            cmd = [sys.executable, *args]
+            cmd = [sys.executable, *cmd_args]
         else:
-            cmd = [sys.executable, "-m", "pupil_labs.neon_player", *args]
+            cmd = [sys.executable, "-m", "pupil_labs.neon_player", *cmd_args]
 
         logging.debug(f"Executing bg job {' '.join(cmd)}")
 

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -158,6 +158,11 @@ class Plugin(PersistentPropertiesMixin, QObject):
 
     @property
     @property_params(widget=None, dont_encode=True)
+    def export_window(self) -> list[int]:
+        return self.app.plugin_settings.export_window
+
+    @property
+    @property_params(widget=None, dont_encode=True)
     def app(self) -> "NeonPlayerApp":
         return neon_player.instance()
 

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -159,7 +159,7 @@ class Plugin(PersistentPropertiesMixin, QObject):
     @property
     @property_params(widget=None, dont_encode=True)
     def export_window(self) -> list[int]:
-        return self.app.plugin_settings.export_window
+        return self.app.session_settings.export_window
 
     @property
     @property_params(widget=None, dont_encode=True)

--- a/src/pupil_labs/neon_player/plugins/blinks.py
+++ b/src/pupil_labs/neon_player/plugins/blinks.py
@@ -30,7 +30,7 @@ class BlinksPlugin(neon_player.Plugin):
         blink_ids = 1 + np.arange(len(self.recording.blinks))
         blinks = self.recording.blinks
 
-        start_time, stop_time = neon_player.instance().recording_settings.export_window
+        start_time, stop_time = self.export_window
         start_mask = blinks.stop_time > start_time
         stop_mask = blinks.start_time < stop_time
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -388,7 +388,7 @@ class EventsPlugin(neon_player.Plugin):
     @action
     @action_params(compact=True, icon=QIcon(str(neon_player.asset_path("export.svg"))))
     def export(self, destination: Path = Path()):
-        start_time, stop_time = neon_player.instance().recording_settings.export_window
+        start_time, stop_time = self.export_window
         event_names = []
         for uid in self.events:
             name = uid if uid in IMMUTABLE_EVENTS else self.get_event_type(uid).name

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -81,6 +81,7 @@ class EventsPlugin(neon_player.Plugin):
     def __init__(self) -> None:
         super().__init__()
         self._event_types: list[EventType] = []
+        self._share_event_types = False
         self.get_timeline().key_pressed.connect(self._on_key_pressed)
         self.header_action = ListPropertyAppenderAction(
             "event_types", "+ Add event type"
@@ -295,6 +296,7 @@ class EventsPlugin(neon_player.Plugin):
         item_params={"label_field": "name"},
         prevent_add=True,
         primary=True,
+        scope="recording",
     )
     def event_types(self) -> list[EventType]:
         return self._event_types

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -81,7 +81,6 @@ class EventsPlugin(neon_player.Plugin):
     def __init__(self) -> None:
         super().__init__()
         self._event_types: list[EventType] = []
-        self._share_event_types = False
         self.get_timeline().key_pressed.connect(self._on_key_pressed)
         self.header_action = ListPropertyAppenderAction(
             "event_types", "+ Add event type"

--- a/src/pupil_labs/neon_player/plugins/export_all.py
+++ b/src/pupil_labs/neon_player/plugins/export_all.py
@@ -52,11 +52,10 @@ class ExportAllPlugin(neon_player.Plugin):
             except Exception:
                 app_version = "?"
 
-            export_window = neon_player.instance().recording_settings.export_window
-            frame_indicies = [self.get_scene_idx_for_time(t) for t in export_window]
+            frame_indicies = [self.get_scene_idx_for_time(t) for t in self.export_window]
             rel_times_formatted = [
                 self.format_duration((t - self.recording.start_time) / 1e9)
-                for t in export_window
+                for t in self.export_window
             ]
 
             now = datetime.now().astimezone()
@@ -66,7 +65,7 @@ class ExportAllPlugin(neon_player.Plugin):
                 "Export Time": now.strftime("%H:%M:%S"),
                 "Frame Index Range": f"{frame_indicies[0]} - {frame_indicies[1]}",
                 "Relative Time Range": f"{rel_times_formatted[0]} - {rel_times_formatted[1]}",
-                "Absolute Time Range": f"{export_window[0]} - {export_window[1]}",
+                "Absolute Time Range": f"{self.export_window[0]} - {self.export_window[1]}",
             }
             export_file = destination / "export_info.csv"
             with export_file.open("w") as out_file:

--- a/src/pupil_labs/neon_player/plugins/eyestate.py
+++ b/src/pupil_labs/neon_player/plugins/eyestate.py
@@ -230,7 +230,7 @@ class EyestatePlugin(PlotProps, neon_player.Plugin):
 
         export_file = destination / "3d_eye_states.csv"
 
-        start_time, stop_time = neon_player.instance().recording_settings.export_window
+        start_time, stop_time = self.export_window
         start_mask = self.eyestate_data["timestamp [ns]"] >= start_time
         stop_mask = self.eyestate_data["timestamp [ns]"] <= stop_time
 

--- a/src/pupil_labs/neon_player/plugins/fixations.py
+++ b/src/pupil_labs/neon_player/plugins/fixations.py
@@ -161,7 +161,7 @@ class FixationsPlugin(neon_player.Plugin):
         self.unregister_action("Playback/Previous Fixation")
 
     def get_export_fixations(self) -> pd.DataFrame:
-        start_time, stop_time = neon_player.instance().recording_settings.export_window
+        start_time, stop_time = self.export_window
         start_mask = self.recording.fixations.stop_time > start_time
         stop_mask = self.recording.fixations.start_time < stop_time
 
@@ -201,7 +201,7 @@ class FixationsPlugin(neon_player.Plugin):
         return export_data
 
     def get_export_saccades(self) -> pd.DataFrame:
-        start_time, stop_time = neon_player.instance().recording_settings.export_window
+        start_time, stop_time = self.export_window
         start_mask = self.recording.saccades.stop_time > start_time
         stop_mask = self.recording.saccades.start_time < stop_time
 

--- a/src/pupil_labs/neon_player/plugins/gaze.py
+++ b/src/pupil_labs/neon_player/plugins/gaze.py
@@ -241,7 +241,7 @@ class GazeDataPlugin(neon_player.Plugin):
         logging.info(f"Wrote {export_file}")
 
     @property
-    @property_params(min=-1, max=1, step=0.01, decimals=3)
+    @property_params(min=-1, max=1, step=0.01, decimals=3, shared=False)
     def offset_x(self) -> float:
         return self._offset_x
 
@@ -251,7 +251,7 @@ class GazeDataPlugin(neon_player.Plugin):
         self.offset_changed.emit()
 
     @property
-    @property_params(min=-1, max=1, step=0.01, decimals=3)
+    @property_params(min=-1, max=1, step=0.01, decimals=3, shared=False)
     def offset_y(self) -> float:
         return self._offset_y
 

--- a/src/pupil_labs/neon_player/plugins/gaze.py
+++ b/src/pupil_labs/neon_player/plugins/gaze.py
@@ -177,7 +177,7 @@ class GazeDataPlugin(neon_player.Plugin):
         if self.recording is None:
             return
 
-        start_time, stop_time = neon_player.instance().recording_settings.export_window
+        start_time, stop_time = self.export_window
         start_mask = self.recording.gaze.time >= start_time
         stop_mask = self.recording.gaze.time <= stop_time
 

--- a/src/pupil_labs/neon_player/plugins/gaze.py
+++ b/src/pupil_labs/neon_player/plugins/gaze.py
@@ -241,7 +241,7 @@ class GazeDataPlugin(neon_player.Plugin):
         logging.info(f"Wrote {export_file}")
 
     @property
-    @property_params(min=-1, max=1, step=0.01, decimals=3, shared=False)
+    @property_params(min=-1, max=1, step=0.01, decimals=3, scope="recording")
     def offset_x(self) -> float:
         return self._offset_x
 
@@ -251,7 +251,7 @@ class GazeDataPlugin(neon_player.Plugin):
         self.offset_changed.emit()
 
     @property
-    @property_params(min=-1, max=1, step=0.01, decimals=3, shared=False)
+    @property_params(min=-1, max=1, step=0.01, decimals=3, scope="recording")
     def offset_y(self) -> float:
         return self._offset_y
 

--- a/src/pupil_labs/neon_player/plugins/imu.py
+++ b/src/pupil_labs/neon_player/plugins/imu.py
@@ -104,7 +104,7 @@ class IMUPlugin(neon_player.Plugin):
         if self.imu_data is None:
             return
 
-        start_time, stop_time = neon_player.instance().recording_settings.export_window
+        start_time, stop_time = self.export_window
         start_mask = self.imu_data["timestamp [ns]"] >= start_time
         stop_mask = self.imu_data["timestamp [ns]"] <= stop_time
 

--- a/src/pupil_labs/neon_player/plugins/scene_renderer.py
+++ b/src/pupil_labs/neon_player/plugins/scene_renderer.py
@@ -110,7 +110,7 @@ class SceneRendererPlugin(Plugin, BackgroundVideoExportMixin):
     def bg_export(self, destination: Path = Path()) -> T.Generator[ProgressUpdate, None, None]:
         yield from self.bg_export_video(
             recording=self.app.recording,
-            export_window=self.app.recording_settings.export_window,
+            export_window=self.export_window,
             render_fn=self.render_for_export,
             destination=destination,
             output_video_filename="scene.mp4",

--- a/src/pupil_labs/neon_player/plugins/scene_renderer.py
+++ b/src/pupil_labs/neon_player/plugins/scene_renderer.py
@@ -68,7 +68,7 @@ class SceneRendererPlugin(Plugin, BackgroundVideoExportMixin):
         self.changed.emit()
 
     @property
-    @property_params(min=0, max=100, shared=False)
+    @property_params(min=0, max=100, scope="recording")
     def brightness(self) -> int:
         return self._brightness
 
@@ -77,7 +77,7 @@ class SceneRendererPlugin(Plugin, BackgroundVideoExportMixin):
         self._brightness = value
 
     @property
-    @property_params(min=0.0, max=3.0, shared=False)
+    @property_params(min=0.0, max=3.0, scope="recording")
     def contrast(self) -> float:
         return self._contrast
 

--- a/src/pupil_labs/neon_player/plugins/scene_renderer.py
+++ b/src/pupil_labs/neon_player/plugins/scene_renderer.py
@@ -68,7 +68,7 @@ class SceneRendererPlugin(Plugin, BackgroundVideoExportMixin):
         self.changed.emit()
 
     @property
-    @property_params(min=0, max=100)
+    @property_params(min=0, max=100, shared=False)
     def brightness(self) -> int:
         return self._brightness
 
@@ -77,7 +77,7 @@ class SceneRendererPlugin(Plugin, BackgroundVideoExportMixin):
         self._brightness = value
 
     @property
-    @property_params(min=0.0, max=3.0)
+    @property_params(min=0.0, max=3.0, shared=False)
     def contrast(self) -> float:
         return self._contrast
 

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
@@ -266,8 +266,7 @@ class SurfaceTrackingPlugin(Plugin):
 
             show_heatmap = surface.show_heatmap and surface.heatmap_alpha > 0.0
             if show_heatmap and surface._heatmap is not None:
-                export_window = self.app.recording_settings.export_window
-                if export_window[0] <= time_in_recording <= export_window[1]:
+                if self.export_window[0] <= time_in_recording <= self.export_window[1]:
                     scalar = np.float64([
                         [1 / surface._heatmap.shape[1], 0.0, 0.0],
                         [0.0, 1 / surface._heatmap.shape[0], 0.0],
@@ -572,7 +571,7 @@ class SurfaceTrackingPlugin(Plugin):
     ) -> T.Generator[ProgressUpdate, None, None]:
         surface = self.get_surface(surface_uid)
 
-        start_time, stop_time = neon_player.instance().recording_settings.export_window
+        start_time, stop_time = self.export_window
         start_mask = self.recording.scene.time >= start_time
         stop_mask = self.recording.scene.time <= stop_time
         scene_frames = self.recording.scene[start_mask & stop_mask]
@@ -902,7 +901,7 @@ class SurfaceTrackingPlugin(Plugin):
     ) -> T.Generator[ProgressUpdate, None, None]:
         surface = self.get_surface(uid)
 
-        start_time, stop_time = neon_player.instance().recording_settings.export_window
+        start_time, stop_time = self.export_window
         start_mask = self.recording.scene.time >= start_time
         stop_mask = self.recording.scene.time <= stop_time
         scene_frames = self.recording.scene[start_mask & stop_mask]
@@ -1005,7 +1004,7 @@ class SurfaceTrackingPlugin(Plugin):
             )
 
     def _get_gazes_in_export_window(self):
-        start_time, stop_time = neon_player.instance().recording_settings.export_window
+        start_time, stop_time = self.export_window
         start_mask = self.recording.gaze.time >= start_time
         stop_mask = self.recording.gaze.time <= stop_time
 

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
@@ -699,6 +699,7 @@ class SurfaceTrackingPlugin(Plugin):
         prevent_add=True,
         item_params={"label_field": "name"},
         primary=True,
+        scope="recording",
     )
     def surfaces(self) -> list["TrackedSurface"]:
         return self._surfaces

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
@@ -41,7 +41,7 @@ from qt_property_widgets.utilities import action_params, property_params
 
 from pupil_labs import neon_player
 from pupil_labs.neon_player import Plugin, ProgressUpdate, action
-from pupil_labs.neon_player.settings import RecordingSettings
+from pupil_labs.neon_player.settings import SessionSettings
 from pupil_labs.neon_player.ui import ListPropertyAppenderAction
 from pupil_labs.neon_player.utilities import (
     SlotDebouncer,
@@ -939,7 +939,7 @@ class SurfaceTrackingPlugin(Plugin):
     def import_surface_definitions(self, source: Path = Path()) -> None:
         # get surface definitions from json
         json_path = source / ".neon_player" / "settings.json"
-        other_recording = RecordingSettings.from_dict(json.load(json_path.open("r")))
+        other_recording = SessionSettings.from_dict(json.load(json_path.open("r")))
         surface_settings = other_recording.plugin_states.get('SurfaceTrackingPlugin', {})
         surfaces = surface_settings.get('surfaces', [])
         if len(surfaces) == 0:

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
@@ -174,7 +174,8 @@ class TrackedSurface(PersistentPropertiesMixin, QObject):
         self.corner_positions = {}
         self.jobs = []
 
-        neon_player.instance().recording_settings.export_window_changed.connect(
+        # XXX: test
+        neon_player.instance().plugin_settings.export_window_changed.connect(
             self.heatmap_invalidated.emit
         )
         self.locations_invalidated.connect(self.heatmap_invalidated.emit)

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
@@ -174,8 +174,7 @@ class TrackedSurface(PersistentPropertiesMixin, QObject):
         self.corner_positions = {}
         self.jobs = []
 
-        # XXX: test
-        neon_player.instance().plugin_settings.export_window_changed.connect(
+        neon_player.instance().export_window_changed.connect(
             self.heatmap_invalidated.emit
         )
         self.locations_invalidated.connect(self.heatmap_invalidated.emit)

--- a/src/pupil_labs/neon_player/plugins/video_exporter.py
+++ b/src/pupil_labs/neon_player/plugins/video_exporter.py
@@ -39,7 +39,7 @@ class VideoExporter(neon_player.Plugin, BackgroundVideoExportMixin):
     def bg_export(self, destination: Path = Path()) -> T.Generator:
         yield from self.bg_export_video(
             recording=self.app.recording,
-            export_window=self.app.recording_settings.export_window,
+            export_window=self.export_window,
             render_fn=self.render_for_export,
             destination=destination,
             output_video_filename="world.mp4",

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -1,8 +1,15 @@
+import json
+import logging
+
+from pathlib import Path
 from PySide6.QtCore import QObject, Signal
-from qt_property_widgets.utilities import PersistentPropertiesMixin, property_params
+from qt_property_widgets.utilities import (
+    PersistentPropertiesMixin, property_params, ComplexEncoder
+)
 
 from pupil_labs import neon_player
 from pupil_labs.neon_player import GlobalPluginProperties, Plugin
+from pupil_labs.neon_recording import NeonRecording
 
 
 def plugin_label_lookup(cls_name: str) -> str:
@@ -121,7 +128,8 @@ class RecordingSettings(PersistentPropertiesMixin, QObject):
     @property_params(widget=None)
     def plugin_states(self) -> dict[str, dict]:
         app = neon_player.instance()
-        if app.recording_settings == self:
+        # XXX: double-check
+        if app.plugin_settings.recording_settings == self:
             current_states = {
                 class_name: p.to_dict() for class_name, p in app.plugins_by_class.items()
             }
@@ -141,3 +149,87 @@ class RecordingSettings(PersistentPropertiesMixin, QObject):
         for kls in Plugin.known_classes:
             if kls.__name__ not in state["enabled_plugins"]:
                 self._enabled_plugins[kls.__name__] = False
+
+
+class PluginSettingsDispatcher(QObject):
+    changed = Signal()
+    export_window_changed = Signal()
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.recording_settings = RecordingSettings()
+        self.workspace_settings = RecordingSettings()
+        self.batch_mode_enabled = False
+        self.default_source = self.recording_settings
+
+    def load_recording_settings(self, settings_path: Path, recording: NeonRecording) -> None:
+        try:
+            if settings_path.exists():
+                logging.info(f"Loading recording settings from {settings_path}")
+                self.recording_settings = RecordingSettings.from_dict(
+                    json.loads(settings_path.read_text())
+                )
+
+                if len(self.recording_settings.export_window) != 2:
+                    logging.warning("Invalid export window in settings")
+                    self.recording_settings.export_window = [
+                        recording.start_time,
+                        recording.stop_time,
+                    ]
+
+            else:
+                self.recording_settings = RecordingSettings()
+                self.recording_settings.export_window = [
+                    recording.start_time,
+                    recording.stop_time,
+                ]
+
+        except Exception:
+            logging.exception("Failed to load settings")
+            self.recording_settings = RecordingSettings()
+
+        logging.info(
+            "Recording settings loaded", self.recording_settings.enabled_plugins
+        )
+
+    def save_recording_settings(self, settings_path: Path) -> None:
+        settings_path.parent.mkdir(parents=True, exist_ok=True)
+        data = self.recording_settings.to_dict()
+        with settings_path.open("w") as f:
+            json.dump(data, f, cls=ComplexEncoder)
+
+    def set_batch_mode(self, batch_mode_enabled: bool) -> None:
+        self.batch_mode_enabled = batch_mode_enabled
+        self.default_source = (
+            self.recording_settings
+            if not batch_mode_enabled else self.workspace_settings
+        )
+
+    @property
+    def export_window(self) -> list[int]:
+        return self.recording_settings.export_window
+
+    @export_window.setter
+    def export_window(self, value: list[int]) -> None:
+        self.recording_settings.export_window = value
+        self.export_window_changed.emit()
+
+    @property
+    @property_params(label_lookup=plugin_label_lookup)
+    def enabled_plugins(self) -> dict[str, bool]:
+        return self.default_source.enabled_plugins
+
+    @enabled_plugins.setter
+    def enabled_plugins(self, value: dict[str, bool]) -> None:
+        self.default_source.enabled_plugins = value
+
+    @property
+    def plugin_states(self) -> dict[str, dict]:
+        if not self.batch_mode_enabled:
+            return self.recording_settings.plugin_states
+
+        # TODO: merge workspace and recording settings
+
+    @plugin_states.setter
+    def plugin_states(self, value: dict[str, dict]) -> None:
+        pass

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -129,7 +129,7 @@ class RecordingSettings(PersistentPropertiesMixin):
 
         condition = None
         if app.batch_mode_enabled:
-            shared = not attached_to_workspace
+            shared = True if attached_to_workspace else False
             condition = lambda params: params.get("shared", True) == shared
 
         current_states = {

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -229,7 +229,3 @@ class PluginSettingsDispatcher(QObject):
             return self.recording_settings.plugin_states
 
         # TODO: merge workspace and recording settings
-
-    @plugin_states.setter
-    def plugin_states(self, value: dict[str, dict]) -> None:
-        pass

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -159,10 +159,12 @@ class PluginSettingsDispatcher(QObject):
         super().__init__()
         self.recording_settings = RecordingSettings()
         self.workspace_settings = RecordingSettings()
-        self.batch_mode_enabled = False
-        self.default_source = self.recording_settings
+        self.batch_mode_enabled: bool = False
+        self.default_source: RecordingSettings = self.recording_settings
 
-    def load_recording_settings(self, settings_path: Path, recording: NeonRecording) -> None:
+    def load_recording_settings(
+        self, settings_path: Path, recording: NeonRecording
+    ) -> None:
         try:
             if settings_path.exists():
                 logging.info(f"Loading recording settings from {settings_path}")
@@ -178,6 +180,7 @@ class PluginSettingsDispatcher(QObject):
                     ]
 
             else:
+                logging.info(f"Recording settings file not found, using defaults")
                 self.recording_settings = RecordingSettings()
                 self.recording_settings.export_window = [
                     recording.start_time,
@@ -185,18 +188,44 @@ class PluginSettingsDispatcher(QObject):
                 ]
 
         except Exception:
-            logging.exception("Failed to load settings")
+            logging.exception("Failed to load recording settings")
             self.recording_settings = RecordingSettings()
 
-        logging.info(
-            "Recording settings loaded", self.recording_settings.enabled_plugins
-        )
+        logging.info("Recording settings loaded")
 
-    def save_recording_settings(self, settings_path: Path) -> None:
+    def load_workspace_settings(self, settings_path: Path) -> None:
+        try:
+            if settings_path.exists():
+                logging.info(f"Loading workspace settings from {settings_path}")
+                self.workspace_settings = RecordingSettings.from_dict(
+                    json.loads(settings_path.read_text())
+                )
+            else:
+                logging.info(f"Workspace settings file not found, using defaults")
+                self.workspace_settings = RecordingSettings()
+
+        except Exception:
+            logging.exception("Failed to load workspace settings")
+            self.workspace_settings = RecordingSettings()
+
+        logging.info("Workspace settings loaded")
+
+    @staticmethod
+    def _save_settings_data(data: dict, settings_path: Path) -> None:
         settings_path.parent.mkdir(parents=True, exist_ok=True)
-        data = self.recording_settings.to_dict()
         with settings_path.open("w") as f:
             json.dump(data, f, cls=ComplexEncoder)
+
+    def save_recording_settings(self, settings_path: Path) -> None:
+        data = self.recording_settings.to_dict()
+        self._save_settings_data(data, settings_path)
+
+    def save_workspace_settings(self, settings_path: Path) -> None:
+        if not self.batch_mode_enabled:
+            return
+
+        data = self.workspace_settings.to_dict()
+        self._save_settings_data(data, settings_path)
 
     def set_batch_mode(self, batch_mode_enabled: bool) -> None:
         self.batch_mode_enabled = batch_mode_enabled

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -129,8 +129,10 @@ class RecordingSettings(PersistentPropertiesMixin):
 
         condition = None
         if app.batch_mode_enabled:
-            shared = True if attached_to_workspace else False
-            condition = lambda params: params.get("shared", True) == shared
+            target_scope = "workspace" if attached_to_workspace else "recording"
+            condition = lambda params: (
+                params.get("scope", "workspace") == target_scope
+            )
 
         current_states = {
             class_name: p.to_dict(condition=condition)

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -90,10 +90,7 @@ class GeneralSettings(PersistentPropertiesMixin, QObject):
                     cls.global_properties = v
 
 
-class RecordingSettings(PersistentPropertiesMixin, QObject):
-    changed = Signal()
-    export_window_changed = Signal()
-
+class RecordingSettings(PersistentPropertiesMixin):
     def __init__(self) -> None:
         super().__init__()
         self._enabled_plugins = neon_player.instance().settings.default_plugins.copy()
@@ -108,8 +105,6 @@ class RecordingSettings(PersistentPropertiesMixin, QObject):
     @export_window.setter
     def export_window(self, value: list[int]) -> None:
         self._export_window = value.copy()
-        self.export_window_changed.emit()
-        self.changed.emit()
 
     @property
     @property_params(label_lookup=plugin_label_lookup)
@@ -124,19 +119,32 @@ class RecordingSettings(PersistentPropertiesMixin, QObject):
     def enabled_plugins(self, value: dict[str, bool]) -> None:
         self._enabled_plugins = value.copy()
 
+    def _update_plugin_states(self) -> None:
+        app = neon_player.instance()
+
+        attached_to_recording = app.plugin_settings.recording_settings == self
+        attached_to_workspace = app.plugin_settings.workspace_settings == self
+        if not attached_to_recording and not attached_to_workspace:
+            return
+
+        condition = None
+        if app.batch_mode_enabled:
+            shared = not attached_to_workspace
+            condition = lambda params: params.get("shared", True) == shared
+
+        current_states = {
+            class_name: p.to_dict(condition=condition)
+            for class_name, p in app.plugins_by_class.items()
+        }
+
+        plugin_states = {**self._plugin_states, **current_states}
+
+        self._plugin_states = {k: v for k, v in plugin_states.items() if v}
+
     @property
     @property_params(widget=None)
     def plugin_states(self) -> dict[str, dict]:
-        app = neon_player.instance()
-        # XXX: double-check
-        if app.plugin_settings.recording_settings == self:
-            current_states = {
-                class_name: p.to_dict() for class_name, p in app.plugins_by_class.items()
-            }
-
-            plugin_states = {**self._plugin_states, **current_states}
-
-            self._plugin_states = {k: v for k, v in plugin_states.items() if v}
+        self._update_plugin_states()
 
         return self._plugin_states
 
@@ -159,8 +167,7 @@ class PluginSettingsDispatcher(QObject):
         super().__init__()
         self.recording_settings = RecordingSettings()
         self.workspace_settings = RecordingSettings()
-        self.batch_mode_enabled: bool = False
-        self.default_source: RecordingSettings = self.recording_settings
+        self._batch_mode_enabled: bool = False
 
     def load_recording_settings(
         self, settings_path: Path, recording: NeonRecording
@@ -221,18 +228,23 @@ class PluginSettingsDispatcher(QObject):
         self._save_settings_data(data, settings_path)
 
     def save_workspace_settings(self, settings_path: Path) -> None:
-        if not self.batch_mode_enabled:
-            return
-
         data = self.workspace_settings.to_dict()
         self._save_settings_data(data, settings_path)
 
-    def set_batch_mode(self, batch_mode_enabled: bool) -> None:
-        self.batch_mode_enabled = batch_mode_enabled
-        self.default_source = (
-            self.recording_settings
-            if not batch_mode_enabled else self.workspace_settings
-        )
+    @property
+    def batch_mode_enabled(self) -> bool:
+        return self._batch_mode_enabled
+
+    @batch_mode_enabled.setter
+    def batch_mode_enabled(self, batch_mode_enabled: bool) -> None:
+        self._batch_mode_enabled = batch_mode_enabled
+
+    @property
+    def default_source(self) -> RecordingSettings:
+        if not self.batch_mode_enabled:
+            return self.recording_settings
+
+        return self.workspace_settings
 
     @property
     def export_window(self) -> list[int]:
@@ -242,6 +254,7 @@ class PluginSettingsDispatcher(QObject):
     def export_window(self, value: list[int]) -> None:
         self.recording_settings.export_window = value
         self.export_window_changed.emit()
+        self.changed.emit()
 
     @property
     @property_params(label_lookup=plugin_label_lookup)
@@ -257,4 +270,11 @@ class PluginSettingsDispatcher(QObject):
         if not self.batch_mode_enabled:
             return self.recording_settings.plugin_states
 
-        # TODO: merge workspace and recording settings
+        workspace_states = self.workspace_settings.plugin_states
+        recording_states = self.recording_settings.plugin_states
+        combined_states = {}
+        for class_name in set(workspace_states) | set(recording_states):
+            combined_states[class_name] = workspace_states.get(class_name, {})
+            combined_states[class_name].update(recording_states.get(class_name, {}))
+
+        return combined_states

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -4,7 +4,7 @@ import logging
 from pathlib import Path
 from PySide6.QtCore import QObject, Signal
 from qt_property_widgets.utilities import (
-    PersistentPropertiesMixin, property_params, ComplexEncoder
+    PersistentPropertiesMixin, property_params, ComplexEncoder, get_properties
 )
 
 from pupil_labs import neon_player
@@ -25,6 +25,17 @@ def plugin_label_lookup(cls_name: str) -> str:
         pass
 
     return f"{cls_name} (missing?)"
+
+
+def has_scope(required_scope: str):
+    def condition(params: dict) -> bool:
+        scope = params.get("scope", "workspace")
+        if isinstance(scope, str):
+            scope = [scope]
+
+        return required_scope in scope
+
+    return condition
 
 
 class GeneralSettings(PersistentPropertiesMixin, QObject):
@@ -100,7 +111,7 @@ class RecordingSettings(PersistentPropertiesMixin):
         self._export_window: list[int] = []
 
     @property
-    @property_params(widget=None)
+    @property_params(widget=None, scope="recording")
     def export_window(self) -> list[int]:
         return self._export_window
 
@@ -132,9 +143,7 @@ class RecordingSettings(PersistentPropertiesMixin):
         condition = None
         if app.batch_mode_enabled:
             target_scope = "workspace" if attached_to_workspace else "recording"
-            condition = lambda params: (
-                params.get("scope", "workspace") == target_scope
-            )
+            condition = has_scope(target_scope)
 
         current_states = {
             class_name: p.to_dict(condition=condition)
@@ -148,7 +157,7 @@ class RecordingSettings(PersistentPropertiesMixin):
         self._plugin_states = {k: v for k, v in plugin_states.items() if v}
 
     @property
-    @property_params(widget=None)
+    @property_params(widget=None, scope=["recording", "workspace"])
     def plugin_states(self) -> dict[str, dict]:
         self._update_plugin_states()
 
@@ -174,6 +183,24 @@ class PluginSettingsDispatcher(QObject):
         self.recording_settings = RecordingSettings()
         self.workspace_settings = RecordingSettings()
         self._batch_mode_enabled: bool = False
+
+    @staticmethod
+    def get_property_scopes(plugin: Plugin) -> dict[str]:
+        properties = get_properties(plugin.__class__)
+        scopes = {}
+
+        for prop_name, prop in properties.items():
+            if not prop.fget:
+                continue
+
+            params = getattr(prop.fget, "parameters", {})
+            scope = params.get("scope", "workspace")
+            if isinstance(scope, str):
+                scope = [scope]
+
+            scopes[prop_name] = scope
+
+        return scopes
 
     def load_recording_settings(
         self, settings_path: Path, recording: NeonRecording
@@ -203,6 +230,10 @@ class PluginSettingsDispatcher(QObject):
         except Exception:
             logging.exception("Failed to load recording settings")
             self.recording_settings = RecordingSettings()
+            self.recording_settings.export_window = [
+                recording.start_time,
+                recording.stop_time,
+            ]
 
         logging.info("Recording settings loaded")
 
@@ -231,8 +262,6 @@ class PluginSettingsDispatcher(QObject):
 
     def save_recording_settings(self, settings_path: Path) -> None:
         data = self.recording_settings.to_dict()
-        if self.batch_mode_enabled:
-            del data["enabled_plugins"]
         self._save_settings_data(data, settings_path)
 
     def save_workspace_settings(self, settings_path: Path) -> None:
@@ -278,11 +307,14 @@ class PluginSettingsDispatcher(QObject):
         if not self.batch_mode_enabled:
             return self.recording_settings.plugin_states
 
-        workspace_states = self.workspace_settings.plugin_states
-        recording_states = self.recording_settings.plugin_states
-        combined_states = {}
-        for class_name in set(workspace_states) | set(recording_states):
-            combined_states[class_name] = workspace_states.get(class_name, {})
-            combined_states[class_name].update(recording_states.get(class_name, {}))
+        workspace_states = self.workspace_settings.to_dict(
+            condition=has_scope("workspace")
+        )["plugin_states"]
+        recording_states = self.recording_settings.to_dict(
+            condition=has_scope("recording")
+        )["plugin_states"]
+        combined_states = merge_plugin_states(
+            workspace_states, recording_states, level="inner"
+        )
 
         return combined_states

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -162,7 +162,7 @@ class GeneralSettings(PersistentPropertiesMixin, QObject):
                     cls.global_properties = v
 
 
-class RecordingSettings(PersistentPropertiesMixin):
+class SessionSettings(PersistentPropertiesMixin):
     def __init__(self) -> None:
         super().__init__()
         self._enabled_plugins = neon_player.instance().settings.default_plugins.copy()
@@ -195,8 +195,8 @@ class RecordingSettings(PersistentPropertiesMixin):
     def _update_plugin_states(self) -> None:
         app = neon_player.instance()
 
-        attached_to_recording = app.plugin_settings.recording_settings == self
-        attached_to_workspace = app.plugin_settings.workspace_settings == self
+        attached_to_recording = app.session_settings.recording_settings == self
+        attached_to_workspace = app.session_settings.workspace_settings == self
         if not attached_to_recording and not attached_to_workspace:
             return
 
@@ -247,8 +247,8 @@ class PluginSettingsDispatcher(QObject):
 
     def __init__(self) -> None:
         super().__init__()
-        self.recording_settings = RecordingSettings()
-        self.workspace_settings = RecordingSettings()
+        self.recording_settings = SessionSettings()
+        self.workspace_settings = SessionSettings()
         self._batch_mode_enabled: bool = False
 
         self.property_scopes: dict[str, dict] = {}
@@ -262,7 +262,7 @@ class PluginSettingsDispatcher(QObject):
         try:
             if settings_path.exists():
                 logging.info(f"Loading recording settings from {settings_path}")
-                self.recording_settings = RecordingSettings.from_dict(
+                self.recording_settings = SessionSettings.from_dict(
                     json.loads(settings_path.read_text())
                 )
 
@@ -275,7 +275,7 @@ class PluginSettingsDispatcher(QObject):
 
             else:
                 logging.info(f"Recording settings file not found, using defaults")
-                self.recording_settings = RecordingSettings()
+                self.recording_settings = SessionSettings()
                 self.recording_settings.export_window = [
                     recording.start_time,
                     recording.stop_time,
@@ -283,7 +283,7 @@ class PluginSettingsDispatcher(QObject):
 
         except Exception:
             logging.exception("Failed to load recording settings")
-            self.recording_settings = RecordingSettings()
+            self.recording_settings = SessionSettings()
             self.recording_settings.export_window = [
                 recording.start_time,
                 recording.stop_time,
@@ -296,16 +296,16 @@ class PluginSettingsDispatcher(QObject):
         try:
             if settings_path.exists():
                 logging.info(f"Loading workspace settings from {settings_path}")
-                self.workspace_settings = RecordingSettings.from_dict(
+                self.workspace_settings = SessionSettings.from_dict(
                     json.loads(settings_path.read_text())
                 )
             else:
                 logging.info(f"Workspace settings file not found, using defaults")
-                self.workspace_settings = RecordingSettings()
+                self.workspace_settings = SessionSettings()
 
         except Exception:
             logging.exception("Failed to load workspace settings")
-            self.workspace_settings = RecordingSettings()
+            self.workspace_settings = SessionSettings()
 
         self.workspace_settings.property_scopes = self.property_scopes
         logging.info("Workspace settings loaded")
@@ -333,7 +333,7 @@ class PluginSettingsDispatcher(QObject):
         self._batch_mode_enabled = batch_mode_enabled
 
     @property
-    def default_source(self) -> RecordingSettings:
+    def default_source(self) -> SessionSettings:
         if not self.batch_mode_enabled:
             return self.recording_settings
 

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import typing as T
 
 from pathlib import Path
 from PySide6.QtCore import QObject, Signal
@@ -10,8 +11,6 @@ from qt_property_widgets.utilities import (
 from pupil_labs import neon_player
 from pupil_labs.neon_player import GlobalPluginProperties, Plugin
 from pupil_labs.neon_recording import NeonRecording
-
-from pupil_labs.neon_player.utilities import merge_plugin_states
 
 
 def plugin_label_lookup(cls_name: str) -> str:
@@ -27,6 +26,28 @@ def plugin_label_lookup(cls_name: str) -> str:
     return f"{cls_name} (missing?)"
 
 
+def get_property_scopes(plugin_cls: type) -> dict[str, list[str]]:
+    properties = get_properties(plugin_cls)
+    scopes = {}
+
+    for prop_name, prop in properties.items():
+        if not prop.fget:
+            continue
+
+        params = getattr(prop.fget, "parameters", {})
+        encode_ok = not params.get("dont_encode", False)
+        if not encode_ok:
+            continue
+
+        scope = params.get("scope", "workspace")
+        if isinstance(scope, str):
+            scope = [scope]
+
+        scopes[prop_name] = scope
+
+    return scopes
+
+
 def has_scope(required_scope: str):
     def condition(params: dict) -> bool:
         scope = params.get("scope", "workspace")
@@ -36,6 +57,44 @@ def has_scope(required_scope: str):
         return required_scope in scope
 
     return condition
+
+
+def merge_plugin_states(
+    saved_states: dict[str, dict],
+    new_states: dict[str, dict],
+    scopes: dict[str, dict] | None = None,
+    overwrite_condition: T.Callable[[list[str]], bool] | None = None,
+) -> dict[str, dict]:
+    """
+    Merge plugin states, optionally overwriting only properties that match
+    a condition based on their scope.
+
+    :param saved_states: Current plugin states, will be used by default.
+    :param new_states: New plugin states, will overwrite saved states if the condition is met.
+    :param scopes: Optional mapping of plugin properties to their scopes, used
+    to filter which properties to merge based on the provided condition.
+    :param overwrite: Optional function that takes property scopes and returns
+    a boolean indicating whether to overwrite the property. If None, all properties
+    will be merged.
+    :return: Merged plugin states.
+    """
+    condition_present = overwrite_condition is not None
+
+    merged = saved_states.copy()
+    for plugin_name, props in new_states.items():
+        if plugin_name not in merged:
+            merged[plugin_name] = {}
+
+        plugin_scopes = scopes.get(plugin_name, {}) if scopes else {}
+        for prop_name, prop_value in props.items():
+            prop_scopes = plugin_scopes.get(prop_name, [])
+
+            if condition_present and not overwrite_condition(prop_scopes):
+                continue
+
+            merged[plugin_name][prop_name] = prop_value
+
+    return merged
 
 
 class GeneralSettings(PersistentPropertiesMixin, QObject):
@@ -109,6 +168,7 @@ class RecordingSettings(PersistentPropertiesMixin):
         self._enabled_plugins = neon_player.instance().settings.default_plugins.copy()
         self._plugin_states: dict[str, dict] = {}
         self._export_window: list[int] = []
+        self.property_scopes: dict[str, dict] = {}
 
     @property
     @property_params(widget=None, scope="recording")
@@ -140,18 +200,25 @@ class RecordingSettings(PersistentPropertiesMixin):
         if not attached_to_recording and not attached_to_workspace:
             return
 
-        condition = None
-        if app.batch_mode_enabled:
-            target_scope = "workspace" if attached_to_workspace else "recording"
-            condition = has_scope(target_scope)
-
         current_states = {
-            class_name: p.to_dict(condition=condition)
+            class_name: p.to_dict()
             for class_name, p in app.plugins_by_class.items()
         }
 
+        overwrite_condition = None
+        if app.batch_mode_enabled:
+            target_scope = (
+                "workspace" if attached_to_workspace else "recording"
+            )
+            overwrite_condition = lambda scopes: target_scope in scopes
+
+        # Overwrite only properties that are relevant for the current
+        # scope (recording or workspace) when batch mode is enabled
         plugin_states = merge_plugin_states(
-            self._plugin_states, current_states, level="inner"
+            self._plugin_states,
+            current_states,
+            scopes=self.property_scopes,
+            overwrite_condition=overwrite_condition
         )
 
         self._plugin_states = {k: v for k, v in plugin_states.items() if v}
@@ -184,23 +251,10 @@ class PluginSettingsDispatcher(QObject):
         self.workspace_settings = RecordingSettings()
         self._batch_mode_enabled: bool = False
 
-    @staticmethod
-    def get_property_scopes(plugin: Plugin) -> dict[str]:
-        properties = get_properties(plugin.__class__)
-        scopes = {}
-
-        for prop_name, prop in properties.items():
-            if not prop.fget:
-                continue
-
-            params = getattr(prop.fget, "parameters", {})
-            scope = params.get("scope", "workspace")
-            if isinstance(scope, str):
-                scope = [scope]
-
-            scopes[prop_name] = scope
-
-        return scopes
+        self.property_scopes: dict[str, dict] = {}
+        for plugin_cls in Plugin.known_classes:
+            scopes = get_property_scopes(plugin_cls)
+            self.property_scopes[plugin_cls.__name__] = scopes
 
     def load_recording_settings(
         self, settings_path: Path, recording: NeonRecording
@@ -235,6 +289,7 @@ class PluginSettingsDispatcher(QObject):
                 recording.stop_time,
             ]
 
+        self.recording_settings.property_scopes = self.property_scopes
         logging.info("Recording settings loaded")
 
     def load_workspace_settings(self, settings_path: Path) -> None:
@@ -252,6 +307,7 @@ class PluginSettingsDispatcher(QObject):
             logging.exception("Failed to load workspace settings")
             self.workspace_settings = RecordingSettings()
 
+        self.workspace_settings.property_scopes = self.property_scopes
         logging.info("Workspace settings loaded")
 
     @staticmethod
@@ -307,14 +363,15 @@ class PluginSettingsDispatcher(QObject):
         if not self.batch_mode_enabled:
             return self.recording_settings.plugin_states
 
-        workspace_states = self.workspace_settings.to_dict(
-            condition=has_scope("workspace")
-        )["plugin_states"]
-        recording_states = self.recording_settings.to_dict(
-            condition=has_scope("recording")
-        )["plugin_states"]
+        workspace_states = self.workspace_settings.plugin_states
+        recording_states = self.recording_settings.plugin_states
+
+        # Overwrite values of recording-specific properties
         combined_states = merge_plugin_states(
-            workspace_states, recording_states, level="inner"
+            workspace_states,
+            recording_states,
+            scopes=self.property_scopes,
+            overwrite_condition=lambda scopes: "recording" in scopes
         )
 
         return combined_states

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -48,17 +48,6 @@ def get_property_scopes(plugin_cls: type) -> dict[str, list[str]]:
     return scopes
 
 
-def has_scope(required_scope: str):
-    def condition(params: dict) -> bool:
-        scope = params.get("scope", "workspace")
-        if isinstance(scope, str):
-            scope = [scope]
-
-        return required_scope in scope
-
-    return condition
-
-
 def merge_plugin_states(
     saved_states: dict[str, dict],
     new_states: dict[str, dict],
@@ -331,6 +320,8 @@ class PluginSettingsDispatcher(QObject):
     @batch_mode_enabled.setter
     def batch_mode_enabled(self, batch_mode_enabled: bool) -> None:
         self._batch_mode_enabled = batch_mode_enabled
+        if not self._batch_mode_enabled:
+            self.workspace_settings = SessionSettings()
 
     @property
     def default_source(self) -> SessionSettings:

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -11,6 +11,8 @@ from pupil_labs import neon_player
 from pupil_labs.neon_player import GlobalPluginProperties, Plugin
 from pupil_labs.neon_recording import NeonRecording
 
+from pupil_labs.neon_player.utilities import merge_plugin_states
+
 
 def plugin_label_lookup(cls_name: str) -> str:
     try:
@@ -139,7 +141,9 @@ class RecordingSettings(PersistentPropertiesMixin):
             for class_name, p in app.plugins_by_class.items()
         }
 
-        plugin_states = {**self._plugin_states, **current_states}
+        plugin_states = merge_plugin_states(
+            self._plugin_states, current_states, level="inner"
+        )
 
         self._plugin_states = {k: v for k, v in plugin_states.items() if v}
 
@@ -227,6 +231,8 @@ class PluginSettingsDispatcher(QObject):
 
     def save_recording_settings(self, settings_path: Path) -> None:
         data = self.recording_settings.to_dict()
+        if self.batch_mode_enabled:
+            del data["enabled_plugins"]
         self._save_settings_data(data, settings_path)
 
     def save_workspace_settings(self, settings_path: Path) -> None:

--- a/src/pupil_labs/neon_player/ui/settings_panel.py
+++ b/src/pupil_labs/neon_player/ui/settings_panel.py
@@ -80,7 +80,7 @@ class PluginManagerWidget(QWidget):
 
     def show_dialog(self) -> None:
         app = neon_player.instance()
-        form = PropertyWidget.from_property("enabled_plugins", app.recording_settings)
+        form = PropertyWidget.from_property("enabled_plugins", app.plugin_settings)
         form.layout().setContentsMargins(10, 10, 10, 10)
         form.layout().setSpacing(5)
 

--- a/src/pupil_labs/neon_player/ui/settings_panel.py
+++ b/src/pupil_labs/neon_player/ui/settings_panel.py
@@ -80,7 +80,7 @@ class PluginManagerWidget(QWidget):
 
     def show_dialog(self) -> None:
         app = neon_player.instance()
-        form = PropertyWidget.from_property("enabled_plugins", app.plugin_settings)
+        form = PropertyWidget.from_property("enabled_plugins", app.session_settings)
         form.layout().setContentsMargins(10, 10, 10, 10)
         form.layout().setSpacing(5)
 

--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -190,8 +190,8 @@ class TimeLineDock(QWidget):
 
         trim_plot = self.get_timeline_plot("Export window", create_if_missing=True)
         self.trim_markers = [
-            TrimEndMarker(app.recording_settings.export_window[0], plot=trim_plot),
-            TrimEndMarker(app.recording_settings.export_window[1], plot=trim_plot),
+            TrimEndMarker(app.plugin_settings.export_window[0], plot=trim_plot),
+            TrimEndMarker(app.plugin_settings.export_window[1], plot=trim_plot),
         ]
         self.duration_marker = TrimDurationMarker(*self.trim_markers)
         for tm in [*self.trim_markers, self.duration_marker]:
@@ -300,7 +300,7 @@ class TimeLineDock(QWidget):
             min(data_pos.x(), app.recording.stop_time), app.recording.start_time
         )
         app.seek_to(self.dragging.time)
-        app.recording_settings.export_window = self.get_export_window()
+        app.plugin_settings.export_window = self.get_export_window()
 
     def on_trim_area_drag_end(self, event: MouseDragEvent):
         self.dragging = None

--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -190,8 +190,8 @@ class TimeLineDock(QWidget):
 
         trim_plot = self.get_timeline_plot("Export window", create_if_missing=True)
         self.trim_markers = [
-            TrimEndMarker(app.plugin_settings.export_window[0], plot=trim_plot),
-            TrimEndMarker(app.plugin_settings.export_window[1], plot=trim_plot),
+            TrimEndMarker(app.session_settings.export_window[0], plot=trim_plot),
+            TrimEndMarker(app.session_settings.export_window[1], plot=trim_plot),
         ]
         self.duration_marker = TrimDurationMarker(*self.trim_markers)
         for tm in [*self.trim_markers, self.duration_marker]:
@@ -300,7 +300,7 @@ class TimeLineDock(QWidget):
             min(data_pos.x(), app.recording.stop_time), app.recording.start_time
         )
         app.seek_to(self.dragging.time)
-        app.plugin_settings.export_window = self.get_export_window()
+        app.session_settings.export_window = self.get_export_window()
 
     def on_trim_area_drag_end(self, event: MouseDragEvent):
         self.dragging = None

--- a/src/pupil_labs/neon_player/utilities.py
+++ b/src/pupil_labs/neon_player/utilities.py
@@ -139,6 +139,24 @@ def get_scene_intrinsics(recording: NeonRecording) -> tuple[np.ndarray, np.ndarr
     return scene_camera_matrix, scene_distortion_coefficients
 
 
+def merge_plugin_states(
+    first: dict[str, dict],
+    second: dict[str, dict],
+    level: str = "outer"
+) -> dict[str, dict]:
+    if level == "outer":
+        return {**first, **second}
+
+    merged = first.copy()
+    for k, v in second.items():
+        if k in merged:
+            merged[k] = {**merged[k], **v}
+        else:
+            merged[k] = v
+
+    return merged
+
+
 class SignalDebouncer:
     _signal_debouncer_map: T.ClassVar[dict[Signal, "SignalDebouncer"]] = {}
 

--- a/src/pupil_labs/neon_player/utilities.py
+++ b/src/pupil_labs/neon_player/utilities.py
@@ -139,24 +139,6 @@ def get_scene_intrinsics(recording: NeonRecording) -> tuple[np.ndarray, np.ndarr
     return scene_camera_matrix, scene_distortion_coefficients
 
 
-def merge_plugin_states(
-    first: dict[str, dict],
-    second: dict[str, dict],
-    level: str = "outer"
-) -> dict[str, dict]:
-    if level == "outer":
-        return {**first, **second}
-
-    merged = first.copy()
-    for k, v in second.items():
-        if k in merged:
-            merged[k] = {**merged[k], **v}
-        else:
-            merged[k] = v
-
-    return merged
-
-
 class SignalDebouncer:
     _signal_debouncer_map: T.ClassVar[dict[Signal, "SignalDebouncer"]] = {}
 

--- a/src/pupil_labs/neon_player/workspace.py
+++ b/src/pupil_labs/neon_player/workspace.py
@@ -71,6 +71,7 @@ class Workspace(QObject):
 
         self._recording_metadata : dict[str, RecordingMetadata] = {}
         self._recordings : list[NeonRecording] = []
+        self.path : Path | None = None
         self.initialized : bool = False
 
     @property
@@ -97,6 +98,7 @@ class Workspace(QObject):
     def clear(self):
         self._recording_metadata = {}
         self._recordings = []
+        self.path = None
         self.initialized = False
 
     def add_recording(self, path: Path):
@@ -105,6 +107,7 @@ class Workspace(QObject):
         if desc:
             self._recordings.append(nr.load(path))
             self._recording_metadata[desc.name] = desc
+            self.path = path.parent
             self.initialized = True
             self.recording_list_loaded.emit(self.recording_metadata)
 
@@ -114,6 +117,7 @@ class Workspace(QObject):
         recording_list = get_recording_list(path)
         self._recording_metadata = {rec.name: rec for rec in recording_list}
         self._recordings = [nr.load(rec.path) for rec in recording_list]
+        self.path = path
 
         logging.info(
             f"Found {self.num_recordings} recordings in the provided folder"

--- a/tests/test_job_manager.py
+++ b/tests/test_job_manager.py
@@ -1,0 +1,86 @@
+import sys
+
+from pathlib import Path
+
+from pupil_labs.neon_player.job_manager import prepare_command
+
+
+def test_prepare_command():
+    recording_path = Path("/path/to/recording")
+    action_name = "Plugin.action"
+    server_name = "neon-player-server-0"
+    
+    expected_cmd = [
+        sys.executable,
+        "-m",
+        "pupil_labs.neon_player",
+        str(recording_path),
+        "--progress-ipc-name",
+        server_name,
+        "--job",
+        action_name,
+    ]
+
+    cmd = prepare_command(
+        recording_path,
+        action_name,
+        args=[],
+        server_name=server_name,
+        batch_mode_enabled=False,
+        is_frozen=False,
+    )
+
+    assert cmd == expected_cmd
+
+
+def test_prepare_command_batch_mode():
+    recording_path = Path("/path/to/recording")
+    action_name = "Plugin.action"
+    server_name = "neon-player-server-0"
+    
+    cmd = prepare_command(
+        recording_path,
+        action_name,
+        args=[],
+        server_name=server_name,
+        batch_mode_enabled=True,
+        is_frozen=False,
+    )
+
+    assert "--workspace" in cmd
+
+
+def test_prepare_command_is_frozen():
+    recording_path = Path("/path/to/recording")
+    action_name = "Plugin.action"
+    server_name = "neon-player-server-0"
+
+    cmd = prepare_command(
+        recording_path,
+        action_name,
+        args=[],
+        server_name=server_name,
+        batch_mode_enabled=False,
+        is_frozen=True,
+    )
+
+    assert "pupil_labs.neon_player" not in cmd
+
+
+def test_prepare_command_job_args_are_forwarded():
+    recording_path = Path("/path/to/recording")
+    action_name = "Plugin.action"
+    server_name = "neon-player-server-0"
+    job_args = ["arg1", "arg2"]
+
+    cmd = prepare_command(
+        recording_path,
+        action_name,
+        args=job_args,
+        server_name=server_name,
+        batch_mode_enabled=True,
+        is_frozen=False,
+    )
+
+    for arg in job_args:
+        assert arg in cmd

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -1,0 +1,120 @@
+from qt_property_widgets.utilities import property_params
+
+from pupil_labs.neon_player import Plugin
+from pupil_labs.neon_player.settings import (
+    get_property_scopes, merge_plugin_states
+)
+
+
+class ExamplePlugin(Plugin):
+    def __init__(self) -> None:
+        super().__init__(connect=False)
+
+    @property
+    @property_params()
+    def default_property(self) -> int:
+        return 10
+
+    @property
+    @property_params(scope="recording")
+    def recording_property(self) -> int:
+        return 20
+
+    @property
+    @property_params(scope="workspace")
+    def workspace_property(self) -> int:
+        return 30
+
+    @property
+    @property_params(scope=["recording", "workspace"])
+    def general_property(self) -> int:
+        return 40
+
+
+def prepare_plugin_states():
+    saved_states = {
+        "ExamplePlugin": {
+            "default_property": 0,
+            "recording_property": 0,
+            "workspace_property": 0,
+            "general_property": 0
+        }
+    }
+
+    current_states = {
+        "ExamplePlugin": {
+            "default_property": 1,
+            "recording_property": 1,
+            "workspace_property": 1,
+            "general_property": 1
+        }
+    }
+
+    return saved_states, current_states
+
+
+def test_settings_get_property_scopes():
+    scopes = get_property_scopes(ExamplePlugin)
+
+    assert len(scopes) == 4
+    assert scopes["default_property"] == ["workspace"]
+    assert scopes["recording_property"] == ["recording"]
+    assert scopes["workspace_property"] == ["workspace"]
+    assert scopes["general_property"] == ["recording", "workspace"]
+
+
+def test_settings_merge_plugin_states_no_condition():
+    saved_states, current_states = prepare_plugin_states()
+    scopes = {
+        "ExamplePlugin": get_property_scopes(ExamplePlugin)
+    }
+
+    merged_states = merge_plugin_states(
+        saved_states,
+        current_states,
+        scopes,
+        overwrite_condition=None
+    )
+
+    for prop in saved_states["ExamplePlugin"]:
+        assert merged_states["ExamplePlugin"][prop] == 1
+
+
+def test_settings_merge_plugin_states_overwrite_recording_only():
+    saved_states, current_states = prepare_plugin_states()
+    scopes = {
+        "ExamplePlugin": get_property_scopes(ExamplePlugin)
+    }
+
+    merged_states = merge_plugin_states(
+        saved_states,
+        current_states,
+        scopes,
+        overwrite_condition=lambda scopes: "recording" in scopes
+    )
+
+    plugin_states = merged_states["ExamplePlugin"]
+    assert plugin_states["default_property"] == 0
+    assert plugin_states["recording_property"] == 1, plugin_states
+    assert plugin_states["workspace_property"] == 0
+    assert plugin_states["general_property"] == 1
+
+
+def test_settings_merge_plugin_states_overwrite_workspace_only():
+    saved_states, current_states = prepare_plugin_states()
+    scopes = {
+        "ExamplePlugin": get_property_scopes(ExamplePlugin)
+    }
+
+    merged_states = merge_plugin_states(
+        saved_states,
+        current_states,
+        scopes,
+        overwrite_condition=lambda scopes: "workspace" in scopes
+    )
+
+    plugin_states = merged_states["ExamplePlugin"]
+    assert plugin_states["default_property"] == 1
+    assert plugin_states["recording_property"] == 0
+    assert plugin_states["workspace_property"] == 1
+    assert plugin_states["general_property"] == 1

--- a/tests/test_settings.py
+++ b/tests/test_settings.py
@@ -7,9 +7,6 @@ from pupil_labs.neon_player.settings import (
 
 
 class ExamplePlugin(Plugin):
-    def __init__(self) -> None:
-        super().__init__(connect=False)
-
     @property
     @property_params()
     def default_property(self) -> int:


### PR DESCRIPTION
Tested on Ubuntu 24.04 across the following contexts:

- In workspace mode, any changes to the settings that are shared across recordings stay when switching recordings within the workspace, but not appear if opening the same recordings outside of the workspace (lately, not 100% sure whether this behavior is desirable)
- In workspace mode, changes to recording-specific settings stay with the recording no matter in which mode (single recording / workspace) it is opened
- Background jobs also load and use workspace settings when initiated in workspace mode

Current scope of settings for each plugin

- Audio - no settings to share
- Blinks - no settings to share
- Events - event types are recording-specific for now, requires custom logic on the plugin level to share them within the workspace
- Export All - all settings are shared
- Eye Overlay - all settings are shared
- 3D Eye States - all settings are shared
- Fixations & Saccades - all settings for all visualizations are shared
- Gaze Data - gaze offset is recording-specific, visualizations are shared
- IMU Plugin - all settings are shared
- Scene Renderer - 'show frame index' is shared, brightness/contrast are recording-specific
- Surface Tracking - tracked surfaces are recording-specific for now, requires custom logic on the plugin level to share them within the workspace
- Video Exporter - no settings to share