### PR TITLE
fix(surface_tracking): export average x/y coordinates of mapped gaze samples within a fixation

### DIFF
--- a/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
@@ -536,11 +536,14 @@ class TrackedSurface(PersistentPropertiesMixin, QObject):
             upper_pass = np.all(mapped_gazes <= 1.0, axis=1)
             gazes_on_surface = lower_pass & upper_pass
 
-            any_gaze_on_surface = bool(np.any(gazes_on_surface))
-            fixations_on_surfs.append(any_gaze_on_surface)
-            if any_gaze_on_surface:
-                # Take the average of all mapped gaze samples within the fixation
-                mapped_fixation_points[idx, :] = mapped_gazes[gazes_on_surface].mean(axis=0)
+            # Fixation is detected on surface if at least one gaze sample within
+            # the fixation is mapped within the surface boundaries
+            fixations_on_surfs.append(bool(np.any(gazes_on_surface)))
+
+            # Mapped fixation position is derived as the average of all mapped gaze
+            # samples within the fixation
+            if not np.all(np.isnan(mapped_gazes)):
+                mapped_fixation_points[idx, :] = np.nanmean(mapped_gazes, axis=0)
 
         fixation_data["fixation detected on surface"] = fixations_on_surfs
         fixation_data["fixation x [normalized]"] = mapped_fixation_points[:, 0]

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/tracked_surface.py
@@ -174,6 +174,9 @@ class TrackedSurface(PersistentPropertiesMixin, QObject):
         self.corner_positions = {}
         self.jobs = []
 
+        if neon_player.instance() is None:
+            return
+
         neon_player.instance().recording_settings.export_window_changed.connect(
             self.heatmap_invalidated.emit
         )
@@ -496,35 +499,7 @@ class TrackedSurface(PersistentPropertiesMixin, QObject):
             return
 
         fixation_data = fixations_plugin.get_export_fixations()
-        fixation_data["fixation detected on surface"] = False
-
-        fixation_points = fixation_data[["fixation x [px]", "fixation y [px]"]]
-        mapped_fixation_points = self.map_points_by_time(
-            fixation_points, fixation_data["start timestamp [ns]"]
-        )
-
-        fixation_data["fixation x [normalized]"] = mapped_fixation_points[:, 0]
-        fixation_data["fixation y [normalized]"] = mapped_fixation_points[:, 1]
-
-        fixations_on_surfs = []
-        for idx, fixation in enumerate(fixation_data.iterrows()):
-            start_mask = gazes.time >= fixation[1]["start timestamp [ns]"]
-            end_mask = gazes.time <= fixation[1]["end timestamp [ns]"]
-            fixation_gazes = gazes[start_mask & end_mask]
-
-            if not fixation_gazes.size:
-                fixations_on_surfs.append(False)
-                continue
-
-            mapped_gazes = self.apply_offset_and_map_gazes(fixation_gazes)
-
-            lower_pass = np.all(mapped_gazes >= 0, axis=1)
-            upper_pass = np.all(mapped_gazes <= 1.0, axis=1)
-            gazes_on_surface = lower_pass & upper_pass
-
-            fixations_on_surfs.append(bool(np.any(gazes_on_surface)))
-
-        fixation_data["fixation detected on surface"] = fixations_on_surfs
+        fixation_data = self._append_mapped_fixation_data(gazes, fixation_data)
 
         # drop unused columns
         fixation_data = fixation_data.drop(
@@ -540,6 +515,38 @@ class TrackedSurface(PersistentPropertiesMixin, QObject):
         fixation_data.to_csv(
             destination / f"fixations_on_surface_{self.name}.csv", index=False
         )
+
+    def _append_mapped_fixation_data(self, gazes, fixation_data):
+        fixation_data["fixation detected on surface"] = False
+
+        fixations_on_surfs = []
+        mapped_fixation_points = np.full((len(fixation_data), 2), np.nan)
+        for idx, (_, fixation) in enumerate(fixation_data.iterrows()):
+            start_mask = gazes.time >= fixation["start timestamp [ns]"]
+            end_mask = gazes.time <= fixation["end timestamp [ns]"]
+            fixation_gazes = gazes[start_mask & end_mask]
+
+            if not fixation_gazes.size:
+                fixations_on_surfs.append(False)
+                continue
+
+            mapped_gazes = self.apply_offset_and_map_gazes(fixation_gazes)
+
+            lower_pass = np.all(mapped_gazes >= 0, axis=1)
+            upper_pass = np.all(mapped_gazes <= 1.0, axis=1)
+            gazes_on_surface = lower_pass & upper_pass
+
+            any_gaze_on_surface = bool(np.any(gazes_on_surface))
+            fixations_on_surfs.append(any_gaze_on_surface)
+            if any_gaze_on_surface:
+                # Take the average of all mapped gaze samples within the fixation
+                mapped_fixation_points[idx, :] = mapped_gazes[gazes_on_surface].mean(axis=0)
+
+        fixation_data["fixation detected on surface"] = fixations_on_surfs
+        fixation_data["fixation x [normalized]"] = mapped_fixation_points[:, 0]
+        fixation_data["fixation y [normalized]"] = mapped_fixation_points[:, 1]
+
+        return fixation_data
 
     def render(self, painter: QPainter, time_in_recording: int = -1) -> None:
         if self.location is None:

--- a/tests/test_plugins/test_surface_tracking/test_tracked_surface.py
+++ b/tests/test_plugins/test_surface_tracking/test_tracked_surface.py
@@ -22,7 +22,7 @@ def mock_gaze_timeseries(time, point_x, point_y):
 
 def _prepare_test_data():
     """
-    Four fixations with two gaze samples each, only the first two are mapped to
+    Five fixations with two gaze samples each, only the first two are mapped to
     the surface (see side effect of the mocked method).
     """
 
@@ -33,15 +33,10 @@ def _prepare_test_data():
         point_y=[15, 25, 35, 45, 55, 65, 75, 85, 95, 105],
     )
     fixation_data = pd.DataFrame({
-        "recording id": ["test"] * 5,
         "fixation id": [1, 2, 3, 4, 5],
         "start timestamp [ns]": [500, 2500, 4500, 6500, 8500],
         "end timestamp [ns]": [2500, 4500, 6500, 8500, 10500],
         "duration [ms]": [2000, 2000, 2000, 2000, 2000],
-        "fixation x [px]": [20, 40, 60, 80, 100],
-        "fixation y [px]": [25, 45, 65, 85, 105],
-        "azimuth [deg]": [0, 0, 0, 0, 0],
-        "elevation [deg]": [0, 0, 0, 0, 0],
     })
 
     surface.apply_offset_and_map_gazes = MagicMock(

--- a/tests/test_plugins/test_surface_tracking/test_tracked_surface.py
+++ b/tests/test_plugins/test_surface_tracking/test_tracked_surface.py
@@ -1,0 +1,98 @@
+import numpy as np
+import pandas as pd
+import pytest
+
+from unittest.mock import MagicMock
+
+from pupil_labs.neon_player.plugins.surface_tracking.tracked_surface import TrackedSurface
+from pupil_labs.neon_recording.timeseries.gaze import GazeTimeseries, GazeArray
+
+
+def mock_gaze_timeseries(time, point_x, point_y):
+    data = np.array([
+        np.void(
+            (t, x, y),
+            dtype=[("time", np.int64), ("point_x", np.float32), ("point_y", np.float32)]
+        )
+        for t, x, y in zip(time, point_x, point_y)
+    ])
+    data = data.view(GazeArray)
+    return GazeTimeseries("", data=data)
+
+
+def _prepare_test_data():
+    """
+    Four fixations with two gaze samples each, only the first two are mapped to
+    the surface (see side effect of the mocked method).
+    """
+
+    surface = TrackedSurface()
+    gazes = mock_gaze_timeseries(
+        time=[1000, 2000, 3000, 4000, 5000, 6000, 7000, 8000, 9000, 10000],
+        point_x=[10, 20, 30, 40, 50, 60, 70, 80, 90, 100],
+        point_y=[15, 25, 35, 45, 55, 65, 75, 85, 95, 105],
+    )
+    fixation_data = pd.DataFrame({
+        "recording id": ["test"] * 5,
+        "fixation id": [1, 2, 3, 4, 5],
+        "start timestamp [ns]": [500, 2500, 4500, 6500, 8500],
+        "end timestamp [ns]": [2500, 4500, 6500, 8500, 10500],
+        "duration [ms]": [2000, 2000, 2000, 2000, 2000],
+        "fixation x [px]": [20, 40, 60, 80, 100],
+        "fixation y [px]": [25, 45, 65, 85, 105],
+        "azimuth [deg]": [0, 0, 0, 0, 0],
+        "elevation [deg]": [0, 0, 0, 0, 0],
+    })
+
+    surface.apply_offset_and_map_gazes = MagicMock(
+        side_effect=[
+            # Fixation 1: mapped, average normalized coords = (0.5, 0.5)
+            np.array([[0.2, 0.2], [0.8, 0.8]]),
+            # Fixation 2: mapped, but some gaze samples are not mapped, same average coords
+            np.array([[0.5, 0.5], [np.nan, np.nan]]),
+            # Fixation 3: not mapped, x-coords are outside
+            np.array([[1.2, 0.2], [-0.2, 0.8]]),
+            # Fixation 4: not mapped, y-coords are outside
+            np.array([[0.2, -0.2], [0.8, 1.2]]),
+            # Fixation 5: not mapped, no gaze samples available
+            np.array([[np.nan, np.nan], [np.nan, np.nan]]),
+        ]
+    )
+
+    return surface, gazes, fixation_data
+
+
+def test_tracked_surface_append_mapped_fixation_data_gaze_samples_forwarded():
+    surface, gazes, fixation_data = _prepare_test_data()
+    result = surface._append_mapped_fixation_data(gazes, fixation_data.copy())
+
+    for idx, mock_call in enumerate(surface.apply_offset_and_map_gazes.call_args_list):
+        start_time = fixation_data.loc[idx, "start timestamp [ns]"]
+        end_time = fixation_data.loc[idx, "end timestamp [ns]"]
+
+        expected_mask = (gazes.time >= start_time) & (gazes.time <= end_time)
+        expected_gazes = gazes[expected_mask]
+
+        assert np.array_equal(mock_call[0][0].time, expected_gazes.time)
+
+
+@pytest.mark.parametrize("fixation_id", [1, 2])
+def test_tracked_surface_append_mapped_fixation_data_fixation_should_be_mapped(fixation_id):
+    surface, gazes, fixation_data = _prepare_test_data()
+    result = surface._append_mapped_fixation_data(gazes, fixation_data.copy())
+
+    fixation_row = result[result["fixation id"] == fixation_id]
+    assert fixation_row["fixation detected on surface"].values[0] == True
+    assert fixation_row["fixation x [normalized]"].values[0] == 0.5
+    assert fixation_row["fixation y [normalized]"].values[0] == 0.5
+
+
+@pytest.mark.parametrize("fixation_id", [3, 4, 5])
+def test_tracked_surface_append_mapped_fixation_data_fixation_should_not_be_mapped(fixation_id):
+    surface, gazes, fixation_data = _prepare_test_data()
+    result = surface._append_mapped_fixation_data(gazes, fixation_data.copy())
+
+    fixation_row = result[result["fixation id"] == fixation_id]
+    assert fixation_row["fixation detected on surface"].values[0] == False
+    assert np.isnan(fixation_row["fixation x [normalized]"].values[0])
+    assert np.isnan(fixation_row["fixation y [normalized]"].values[0])

--- a/tests/test_plugins/test_surface_tracking/test_tracked_surface.py
+++ b/tests/test_plugins/test_surface_tracking/test_tracked_surface.py
@@ -51,9 +51,9 @@ def _prepare_test_data():
             # Fixation 2: mapped, but some gaze samples are not mapped, same average coords
             np.array([[0.5, 0.5], [np.nan, np.nan]]),
             # Fixation 3: not mapped, x-coords are outside
-            np.array([[1.2, 0.2], [-0.2, 0.8]]),
+            np.array([[1.3, 0.3], [-0.1, 0.9]]),
             # Fixation 4: not mapped, y-coords are outside
-            np.array([[0.2, -0.2], [0.8, 1.2]]),
+            np.array([[0.3, -0.1], [0.9, 1.3]]),
             # Fixation 5: not mapped, no gaze samples available
             np.array([[np.nan, np.nan], [np.nan, np.nan]]),
         ]
@@ -87,8 +87,19 @@ def test_tracked_surface_append_mapped_fixation_data_fixation_should_be_mapped(f
     assert fixation_row["fixation y [normalized]"].values[0] == 0.5
 
 
-@pytest.mark.parametrize("fixation_id", [3, 4, 5])
+@pytest.mark.parametrize("fixation_id", [3, 4])
 def test_tracked_surface_append_mapped_fixation_data_fixation_should_not_be_mapped(fixation_id):
+    surface, gazes, fixation_data = _prepare_test_data()
+    result = surface._append_mapped_fixation_data(gazes, fixation_data.copy())
+
+    fixation_row = result[result["fixation id"] == fixation_id]
+    assert fixation_row["fixation detected on surface"].values[0] == False
+    assert fixation_row["fixation x [normalized]"].values[0] == 0.6
+    assert fixation_row["fixation y [normalized]"].values[0] == 0.6
+
+
+@pytest.mark.parametrize("fixation_id", [5])
+def test_tracked_surface_append_mapped_fixation_data_fixation_no_mapped_gazes(fixation_id):
     surface, gazes, fixation_data = _prepare_test_data()
     result = surface._append_mapped_fixation_data(gazes, fixation_data.copy())
 


### PR DESCRIPTION
The new approach should be in line with Cloud. In `main`, the mapped coordinates for the first sample within a fixation are currently exported.