### PR TITLE
feat(events): set event as one of the export window boundaries

### DIFF
--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -212,12 +212,12 @@ class EventsPlugin(neon_player.Plugin):
             )
             self.register_data_point_action(
                 f"Events - {event_type.name}",
-                f"Set this {event_type.name} as left export boundary",
+                f"Set this {event_type.name} as the left export window boundary",
                 lambda dp: self.set_event_as_export_boundary(dp, left=True),
             )
             self.register_data_point_action(
                 f"Events - {event_type.name}",
-                f"Set this {event_type.name} as right export boundary",
+                f"Set this {event_type.name} as the right export window boundary",
                 lambda dp: self.set_event_as_export_boundary(dp, left=False),
             )
 
@@ -233,8 +233,8 @@ class EventsPlugin(neon_player.Plugin):
         timeline.remove_timeline_plot(f"Events - {event_name}")
         data_point_actions = [
             f"Seek to this {event_name}",
-            f"Set this {event_name} as left export boundary",
-            f"Set this {event_name} as right export boundary",
+            f"Set this {event_name} as the left export window boundary",
+            f"Set this {event_name} as the right export window boundary",
         ]
         for action_name in data_point_actions:
             timeline.unregister_data_point_action(
@@ -289,9 +289,9 @@ class EventsPlugin(neon_player.Plugin):
         timeline = self.get_timeline()
         current_export_window = timeline.get_export_window()
         if left:
-            new_window = (data_point[0], current_export_window[1])
+            new_window = [data_point[0], current_export_window[1]]
         else:
-            new_window = (current_export_window[0], data_point[0])
+            new_window = [current_export_window[0], data_point[0]]
         timeline.set_export_window(new_window)
         self.app.recording_settings.export_window = new_window
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -286,14 +286,12 @@ class EventsPlugin(neon_player.Plugin):
         self.app.seek_to(data_point[0])
 
     def set_event_as_export_boundary(self, data_point, left: bool):
-        timeline = self.get_timeline()
-        current_export_window = timeline.get_export_window()
+        current_export_window = self.app.get_export_window()
         if left:
-            new_window = [data_point[0], current_export_window[1]]
+            new_window = (data_point[0], current_export_window[1])
         else:
-            new_window = [current_export_window[0], data_point[0]]
-        timeline.set_export_window(new_window)
-        self.app.recording_settings.export_window = new_window
+            new_window = (current_export_window[0], data_point[0])
+        self.app.set_export_window(new_window)
 
     def _update_timeline_data(self, event_type: EventType) -> None:
         timeline = self.get_timeline()

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -210,6 +210,16 @@ class EventsPlugin(neon_player.Plugin):
                 f"Seek to this {event_type.name}",
                 self.seek_to_event_instance,
             )
+            self.register_data_point_action(
+                f"Events - {event_type.name}",
+                f"Set this {event_type.name} as left export boundary",
+                lambda dp: self.set_event_as_export_boundary(dp, left=True),
+            )
+            self.register_data_point_action(
+                f"Events - {event_type.name}",
+                f"Set this {event_type.name} as right export boundary",
+                lambda dp: self.set_event_as_export_boundary(dp, left=False),
+            )
 
         register_data_actions()
         event_type.name_changed.connect(lambda _, _2: register_data_actions())
@@ -221,9 +231,15 @@ class EventsPlugin(neon_player.Plugin):
     ) -> None:
         timeline = self.get_timeline()
         timeline.remove_timeline_plot(f"Events - {event_name}")
-        timeline.unregister_data_point_action(
-            f"Events - {event_name}", f"Seek to this {event_name}"
-        )
+        data_point_actions = [
+            f"Seek to this {event_name}",
+            f"Set this {event_name} as left export boundary",
+            f"Set this {event_name} as right export boundary",
+        ]
+        for action_name in data_point_actions:
+            timeline.unregister_data_point_action(
+                f"Events - {event_name}", action_name
+            )
 
         if event_name in IMMUTABLE_EVENTS:
             return
@@ -268,6 +284,16 @@ class EventsPlugin(neon_player.Plugin):
 
     def seek_to_event_instance(self, data_point) -> None:
         self.app.seek_to(data_point[0])
+
+    def set_event_as_export_boundary(self, data_point, left: bool):
+        timeline = self.get_timeline()
+        current_export_window = timeline.get_export_window()
+        if left:
+            new_window = (data_point[0], current_export_window[1])
+        else:
+            new_window = (current_export_window[0], data_point[0])
+        timeline.set_export_window(new_window)
+        self.app.recording_settings.export_window = new_window
 
     def _update_timeline_data(self, event_type: EventType) -> None:
         timeline = self.get_timeline()


### PR DESCRIPTION
Currently, it is not possible to set one of the events as the start or the end of the export window unless the user manually moves the trim markers to the exact timestamp. The PR adds context menu options "Set this <event> as left/right export boundary", partially addressing the [feature request](https://discord.com/channels/285728493612957698/1503826218384883792) on Discord.

<img width="644" height="196" alt="image" src="https://github.com/user-attachments/assets/6e39004d-a7e7-499a-b028-2c9753d2d12f" />