### PR TITLE
fix(events): refactor events workflow to improve performance 

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,7 @@ jobs:
 
       - name: Install required system dependencies (Ubuntu)
         if: matrix.platform == 'ubuntu-22.04'
-        run: sudo apt-get install -y freeglut3-dev libpulse-dev
+        run: sudo apt-get update && sudo apt-get install -y --fix-missing freeglut3-dev libpulse-dev
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           lfs: "true"
 
+      # Installing all Qt Linux dependencies, see: https://doc.qt.io/qt-6/linux-requirements.html
       - name: Install required system dependencies (Ubuntu)
         if: matrix.platform == 'ubuntu-22.04'
         run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -35,6 +35,8 @@ jobs:
           - windows-latest
           - macOS-14
           - ubuntu-22.04
+    env:
+      DISPLAY: :99.0
     defaults:
       run:
         shell: bash
@@ -48,7 +50,12 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --fix-missing freeglut3-dev libpulse-dev libxkbcommon-x11-0
+          sudo apt-get install -y --fix-missing freeglut3-dev libpulse-dev libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb
+
+      # See: https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
+      - name: Set up xvfb for pytest-qt (Ubuntu)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: /sbin/start-stop-daemon --start --quiet --pidfile /tmp/custom_xvfb_99.pid --make-pidfile --background --exec /usr/bin/Xvfb -- :99 -screen 0 1920x1200x24 -ac +extension GLX
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,35 @@ jobs:
         if: matrix.platform == 'ubuntu-22.04'
         run: |
           sudo apt-get update
-          sudo apt-get install -y --fix-missing freeglut3-dev libpulse-dev libxkbcommon-x11-0 libxcb-icccm4 libxcb-image0 libxcb-keysyms1 libxcb-randr0 libxcb-render-util0 libxcb-xinerama0 libxcb-xfixes0 x11-utils xvfb
+          sudo apt-get install -y --fix-missing \
+            freeglut3-dev \
+            libpulse-dev \
+            libfontconfig1-dev \
+            libfreetype-dev \
+            libgtk-3-dev \
+            libx11-dev \
+            libx11-xcb-dev \
+            libxcb-cursor-dev \
+            libxcb-glx0-dev \
+            libxcb-icccm4-dev \
+            libxcb-image0-dev \
+            libxcb-keysyms1-dev \
+            libxcb-randr0-dev \
+            libxcb-render-util0-dev \
+            libxcb-shape0-dev \
+            libxcb-shm0-dev \
+            libxcb-sync-dev \
+            libxcb-util-dev \
+            libxcb-xfixes0-dev \
+            libxcb-xkb-dev \
+            libxcb1-dev \
+            libxext-dev \
+            libxfixes-dev \
+            libxi-dev \
+            libxkbcommon-dev \
+            libxkbcommon-x11-dev \
+            libxrender-dev \
+            xvfb
 
       # See: https://pytest-qt.readthedocs.io/en/latest/troubleshooting.html#github-actions-azure-pipelines-travis-ci-and-gitlab-ci-cd
       - name: Set up xvfb for pytest-qt (Ubuntu)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,7 +46,9 @@ jobs:
 
       - name: Install required system dependencies (Ubuntu)
         if: matrix.platform == 'ubuntu-22.04'
-        run: sudo apt-get update && sudo apt-get install -y --fix-missing freeglut3-dev libpulse-dev
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --fix-missing freeglut3-dev libpulse-dev libxkbcommon-x11-0
 
       - name: Set up the environment
         uses: ./.github/actions/setup-python-env

--- a/.gitignore
+++ b/.gitignore
@@ -344,3 +344,6 @@ $RECYCLE.BIN/
 *.dist/
 
 src/pupil_labs/neon_player/ui/splash.py
+
+# Temporary test files
+tests/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -344,6 +344,3 @@ $RECYCLE.BIN/
 *.dist/
 
 src/pupil_labs/neon_player/ui/splash.py
-
-# Temporary test files
-tests/tmp

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,15 +55,16 @@ neon-player = "pupil_labs.neon_player.main:main"
 [tool.uv]
 dev-dependencies = [
     "pytest>=8.2",
+    "pytest-qt>=4.5.0",
     "pre-commit>=2.20.0",
     "mypy>=0.991",
     "deptry>=0.20.0",
     "tox-uv>=1.11.3",
     "pytest-cov>=4.0.0",
     # stubs
+    "pandas-stubs>=3.0.3.260530",
     # "opencv-stubs",
     # "types-protobuf",
-    # "pandas-stubs",
     # docs
     "markdown-callouts>=0.4",
     "markdown-exec>=1.8",
@@ -78,7 +79,6 @@ dev-dependencies = [
     "mkdocstrings[python]>=0.25",
     # YORE: EOL 3.10: Remove line.
     "tomli>=2.0; python_version < '3.11'",
-    "pytest-qt>=4.5.0",
 ]
 
 [tool.uv.sources]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -60,12 +60,10 @@ dev-dependencies = [
     "deptry>=0.20.0",
     "tox-uv>=1.11.3",
     "pytest-cov>=4.0.0",
-
     # stubs
     # "opencv-stubs",
     # "types-protobuf",
     # "pandas-stubs",
-
     # docs
     "markdown-callouts>=0.4",
     "markdown-exec>=1.8",
@@ -80,6 +78,7 @@ dev-dependencies = [
     "mkdocstrings[python]>=0.25",
     # YORE: EOL 3.10: Remove line.
     "tomli>=2.0; python_version < '3.11'",
+    "pytest-qt>=4.5.0",
 ]
 
 [tool.uv.sources]

--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -355,8 +355,12 @@ class NeonPlayerApp(QApplication):
         self.set_playback_state(False)
         self.save_settings(force=True)
         class_names = list(self.plugins_by_class.keys())
+
+        timeline = self.main_window.timeline
+        timeline.disable_plot_sorting()
         for plugin_class_name in class_names:
             self.toggle_plugin(plugin_class_name, False)
+        timeline.enable_plot_sorting()
 
         self.recording = None
         self.recording_unloaded.emit()
@@ -422,10 +426,14 @@ class NeonPlayerApp(QApplication):
         logging.info(f"Loaded `{self.recording._rec_dir}`")
 
     def toggle_plugins_by_settings(self) -> None:
+        timeline = self.main_window.timeline
+        timeline.disable_plot_sorting()
+
         for cls_name, enabled in self.recording_settings.enabled_plugins.items():
             state = self.recording_settings.plugin_states.get(cls_name, {})
             self.toggle_plugin(cls_name, enabled, state)
 
+        timeline.enable_plot_sorting()
         self._initializing = False
 
         if self.args.job:

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -38,7 +38,11 @@ class Plugin(PersistentPropertiesMixin, QObject):
         self.render_layer = 1
         self._enabled = False
 
-        neon_player.instance().aboutToQuit.connect(self.on_disabled)
+        app = neon_player.instance()
+        if app is None:
+            return
+
+        app.aboutToQuit.connect(self.on_disabled)
 
     def register_action(
         self, name: str, shortcut: QtShortcutType, func: T.Callable

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -169,11 +169,6 @@ class Plugin(PersistentPropertiesMixin, QObject):
 
     @property
     @property_params(widget=None, dont_encode=True)
-    def headless(self) -> bool:
-        return self.app is None or self.app.headless
-
-    @property
-    @property_params(widget=None, dont_encode=True)
     def job_manager(self) -> "JobManager":
         return neon_player.instance().job_manager
 

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -186,7 +186,7 @@ class Plugin(PersistentPropertiesMixin, QObject):
         raise ValueError(f"Plugin class {name} not found")
 
     @staticmethod
-    def get_instance_by_name(name: str) -> "Plugin":
+    def get_instance_by_name(name: str) -> T.Union["Plugin", None]:
         return neon_player.instance().plugins_by_class.get(name)
 
     @classmethod

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -5,6 +5,7 @@ from pathlib import Path
 from numpyencoder import NumpyEncoder
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtGui import QPainter
+from PySide6.QtWidgets import QMessageBox
 from qt_property_widgets.utilities import PersistentPropertiesMixin, property_params
 
 from pupil_labs import neon_player
@@ -100,6 +101,10 @@ class Plugin(PersistentPropertiesMixin, QObject):
 
     def get_timeline(self) -> TimeLineDock:
         return self.app.main_window.timeline
+
+    def user_confirm(self, title: str, message: str, **kwargs: T.Any) -> bool:
+        reply = QMessageBox.question(None, title, message, **kwargs)
+        return reply == QMessageBox.StandardButton.Yes
 
     def get_cache_path(self) -> Path:
         if self.recording is None:

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -169,6 +169,11 @@ class Plugin(PersistentPropertiesMixin, QObject):
 
     @property
     @property_params(widget=None, dont_encode=True)
+    def headless(self) -> bool:
+        return self.app is None or self.app.headless
+
+    @property
+    @property_params(widget=None, dont_encode=True)
     def job_manager(self) -> "JobManager":
         return neon_player.instance().job_manager
 

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -165,6 +165,11 @@ class Plugin(PersistentPropertiesMixin, QObject):
 
     @property
     @property_params(widget=None, dont_encode=True)
+    def headless(self) -> bool:
+        return self.app is None or self.app.headless
+
+    @property
+    @property_params(widget=None, dont_encode=True)
     def job_manager(self) -> "JobManager":
         return neon_player.instance().job_manager
 

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -102,8 +102,8 @@ class Plugin(PersistentPropertiesMixin, QObject):
     def get_timeline(self) -> TimeLineDock:
         return self.app.main_window.timeline
 
-    def user_confirm(self, title: str, message: str, **kwargs: T.Any) -> bool:
-        reply = QMessageBox.question(None, title, message, **kwargs)
+    def user_confirm(self, title: str, message: str) -> bool:
+        reply = QMessageBox.question(None, title, message)
         return reply == QMessageBox.StandardButton.Yes
 
     def get_cache_path(self) -> Path:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -350,7 +350,7 @@ class EventsPlugin(neon_player.Plugin):
 
         timeline = self.get_timeline()
         existing_plot = timeline.get_timeline_plot(
-            f"Events - {event_type.name}", create_if_not_exists=False
+            f"Events - {event_type.name}", create_if_missing=False
         )
         if existing_plot is not None:
             return
@@ -587,11 +587,16 @@ class EventsPlugin(neon_player.Plugin):
         for event_type in event_types_to_update:
             self._update_timeline_data(event_type)
 
-    def delete_events(self, events: dict[str, list[int]]) -> None:
+    def delete_events(
+        self, events: dict[str, list[int]], remove_empty_types: bool = False
+    ) -> None:
         """
         Delete events specified in the provided dictionary from the existing ones.
         The expected format of the dictionary is {event name: list of timestamps to remove}.
+        Event types, for which all events are removed, are not deleted by default,
+        but can optionally be removed if `remove_empty_types` is set to True.
         """
+        event_types_to_remove = []
         event_types_to_update = []
         for event_name, timestamps in events.items():
             if event_name not in self._event_types_by_name:
@@ -610,11 +615,17 @@ class EventsPlugin(neon_player.Plugin):
             remaining_timestamps = existing_timestamps - timestamps_to_remove
             if not remaining_timestamps:
                 del self._events[event_type.uid]
+                if remove_empty_types:
+                    del self._event_types_by_name[event_name]
+                    event_types_to_remove.append(event_type)
             else:
                 self._events[event_type.uid] = list(remaining_timestamps)
             event_types_to_update.append(event_type)
 
         self.save_cached_json("events.json", self._events)
+        if remove_empty_types and event_types_to_remove:
+            self._update_gui_for_event_types(event_types_to_remove=event_types_to_remove)
+            self.changed.emit()
         for event_type in event_types_to_update:
             self._update_timeline_data(event_type)
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -285,7 +285,7 @@ class EventsPlugin(neon_player.Plugin):
                 f"Add Event/{event_type.name}", None, lambda: self.add_event(event_type)
             )
             self.app.main_window.sort_action_menu("Timeline/Add Event")
-            event_type.name_changed.connect(lambda old, new: action.setText(new))
+            event_type.name_changed.connect(lambda _, new: action.setText(new))
 
         self.register_data_actions(event_type)
 
@@ -417,6 +417,9 @@ class EventsPlugin(neon_player.Plugin):
         self.app.set_export_window(new_window)
 
     def _update_timeline_data(self, event_type: EventType) -> None:
+        if self.headless:
+            return
+
         timeline = self.get_timeline()
         event_name = event_type.name
         plot_item = timeline.get_timeline_plot(f"Events - {event_name}")

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -100,13 +100,9 @@ class EventType(PersistentPropertiesMixin, QObject):
 class EventTypeListWidget(ValueListWidget):
     @staticmethod
     def from_property_impl(prop: property) -> "EventTypeListWidget":
-        hints = T.get_type_hints(prop.fget)
-        return_type = hints["return"]
-        item_type = T.get_args(return_type)[0]
-
         source_params = prop.fget.parameters if hasattr(prop.fget, "parameters") else {}
 
-        return EventTypeListWidget(item_type, source_params)
+        return EventTypeListWidget(EventType, source_params)
 
     @staticmethod
     def from_type(cls: type) -> "EventTypeListWidget":
@@ -144,9 +140,16 @@ class EventTypeListWidget(ValueListWidget):
         plugin.delete_event_type(event_type)
         super().remove_item(item_widget)
 
+
 def _load_events_from_recording(
     recording: NeonRecording, global_event_types: list[str] = []
 ) -> tuple[list[EventType], dict]:
+    """
+    Loads events from the recording and additionally creates event types that
+    are defined in global settings.
+
+    Returns all created event types and the events as {uid: list of timestamps}.
+    """
     event_type_cache = {}
     events = {}
 
@@ -206,6 +209,10 @@ def _load_events_from_cache(
 def _load_events_from_dataframe(
     events_df: pd.DataFrame, existing_event_types: dict[str, EventType]
 ) -> tuple[list[EventType], dict]:
+    """
+    Loads events from the provided dataframe, returning all occurring event types
+    and the events as {uid: list of timestamps}.
+    """
     event_type_cache = {}
     events = {}
 
@@ -239,7 +246,7 @@ class EventsPlugin(neon_player.Plugin):
         self._event_types_by_name: dict[str, EventType] = {}
         self._events: dict[str, list[int]] = {}
 
-        if self.headless:
+        if self.app is None or self.app.headless:
             return
 
         self.get_timeline().key_pressed.connect(self._on_key_pressed)
@@ -249,6 +256,9 @@ class EventsPlugin(neon_player.Plugin):
 
     @staticmethod
     def instance() -> T.Union["EventsPlugin", None]:
+        if neon_player.instance() is None:
+            return None
+
         return Plugin.get_instance_by_name("EventsPlugin")
 
     def _on_key_pressed(self, event: QKeyEvent) -> None:
@@ -305,7 +315,7 @@ class EventsPlugin(neon_player.Plugin):
         self._update_gui_for_event_types(event_types_to_add=event_types_to_update_ui_for)
 
     def on_disabled(self) -> None:
-        if self.recording is None or self.headless:
+        if self.app is None or self.app.headless or self.recording is None:
             return
 
         event_types = list(self._event_types_by_name.values())
@@ -316,7 +326,7 @@ class EventsPlugin(neon_player.Plugin):
         event_types_to_add: list[EventType] = [],
         event_types_to_remove: list[EventType] = []
     ) -> None:
-        if self.headless:
+        if self.app is None or self.app.headless:
             return
 
         if not event_types_to_add and not event_types_to_remove:
@@ -427,6 +437,9 @@ class EventsPlugin(neon_player.Plugin):
         self.changed.emit()
 
     def delete_event_type(self, event_type: EventType) -> None:
+        if event_type.uid not in self._events:
+            return
+
         del self._events[event_type.uid]
         self.save_cached_json("events.json", self._events)
         del self._event_types_by_name[event_type.name]

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -539,7 +539,7 @@ class EventsPlugin(neon_player.Plugin):
     def add_events(self, events: dict[str, list[int]]) -> None:
         """
         Add events from the provided dictionary to the existing ones. The expected
-        format of the dictionary is {event name: list of timestamps}.
+        format of the dictionary is {event name: list of timestamps to add}.
         """
         event_types_to_add = []
         event_types_to_update = []
@@ -558,6 +558,34 @@ class EventsPlugin(neon_player.Plugin):
 
         self.save_cached_json("events.json", self._events)
         self._update_gui_for_event_types(event_types_to_add=event_types_to_add)
+        for event_type in event_types_to_update:
+            self._update_timeline_data(event_type)
+
+    def delete_events(self, events: dict[str, list[int]]) -> None:
+        """
+        Delete events specified in the provided dictionary from the existing ones.
+        The expected format of the dictionary is {event name: list of timestamps to remove}.
+        """
+        event_types_to_remove = []
+        event_types_to_update = []
+        for event_name, timestamps in events.items():
+            if event_name not in self._event_types_by_name:
+                logging.warning(f"Skipping unknown event '{event_name}' from deletion")
+                continue
+
+            event_type = self._event_types_by_name[event_name]
+            existing_timestamps = set(self._events[event_type.uid])
+            timestamps_to_remove = set(timestamps)
+            remaining_timestamps = existing_timestamps - timestamps_to_remove
+            if not remaining_timestamps:
+                del self._events[event_type.uid]
+                event_types_to_remove.append(event_type)
+            else:
+                self._events[event_type.uid] = list(remaining_timestamps)
+                event_types_to_update.append(event_type)
+
+        self.save_cached_json("events.json", self._events)
+        self._update_gui_for_event_types(event_types_to_remove=event_types_to_remove)
         for event_type in event_types_to_update:
             self._update_timeline_data(event_type)
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -117,7 +117,8 @@ class EventTypeListWidget(ValueListWidget):
         if plugin is None:
             return
 
-        new_event_type = plugin.add_event_type()
+        new_event_type = plugin.create_event_type()
+        plugin.add_event_type(new_event_type)
         self.add_item(new_event_type)
 
     def remove_item(self, item_widget: ValueListItemWidget):
@@ -216,7 +217,6 @@ class EventsPlugin(neon_player.Plugin):
     def __init__(self) -> None:
         super().__init__()
         self._event_types_by_name: dict[str, EventType] = {}
-        self._event_type_counter = 1
         self._events: dict[str, list[int]] = {}
 
         if self.headless:
@@ -282,38 +282,47 @@ class EventsPlugin(neon_player.Plugin):
 
         logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
 
-        if self.headless:
-            return
-
-        # Create timeline plots for each event type that is present among the events
-        # Disable plot sorting to improve performance for recording with many events
-        timeline = self.get_timeline()
-        plot_sorting_was_enabled = timeline.disable_plot_sorting()
-        for et in event_types_to_update_ui_for:
-            self._attach_event_type(et)
-            self._setup_gui_for_event_type(et)
-            self._update_timeline_data(et)
-        if plot_sorting_was_enabled:
-            timeline.enable_plot_sorting()
+        self._update_gui_for_event_types(event_types_to_add=event_types_to_update_ui_for)
 
     def on_disabled(self) -> None:
         if self.recording is None or self.headless:
             return
 
+        self._events = {}
+        self._event_types_by_name = {}
+
+        event_types = list(self._event_types_by_name.values())
+        self._update_gui_for_event_types(event_types_to_remove=event_types)
+
+    def _update_gui_for_event_types(
+        self,
+        event_types_to_add: list[EventType] = [],
+        event_types_to_remove: list[EventType] = []
+    ) -> None:
+        if self.headless:
+            return
+
+        if not event_types_to_add and not event_types_to_remove:
+            return
+
+        # Disable plot sorting to improve performance for recording with many events
         timeline = self.get_timeline()
         plot_sorting_was_enabled = timeline.disable_plot_sorting()
-        timeline.remove_timeline_plot("Events")
-        for event_name in self._event_types_by_name:
-            self._remove_gui_for_event_name(event_name)
+
+        for et in event_types_to_add:
+            et.changed.connect(self.changed.emit)
+            et.name_changed.connect(
+                lambda old, new, et=et: self._on_event_name_changed(old, new, et)
+            )
+            self._setup_gui_for_event_type(et)
+            self._update_timeline_data(et)
+
+        for et in event_types_to_remove:
+            self._remove_gui_for_event_name(et.name)
+
+        # Enable plot sorting, sort rows if any were added or removed
         if plot_sorting_was_enabled:
             timeline.enable_plot_sorting()
-
-    def _attach_event_type(self, event_type: EventType) -> None:
-        # Connect the required signals
-        event_type.changed.connect(self.changed.emit)
-        event_type.name_changed.connect(
-            lambda old, new, et=event_type: self._on_event_name_changed(old, new, et)
-        )
 
     def _setup_gui_for_event_type(self, event_type: EventType) -> None:
         timeline = self.get_timeline()
@@ -329,11 +338,10 @@ class EventsPlugin(neon_player.Plugin):
         plot_item.getViewBox().allow_y_panning = False
 
         if event_type.name not in IMMUTABLE_EVENTS:
-            action = self.register_timeline_action(
+            self.register_timeline_action(
                 f"Add Event/{event_type.name}", None, lambda: self.add_event(event_type)
             )
             self.app.main_window.sort_action_menu("Timeline/Add Event")
-            event_type.name_changed.connect(lambda _, new: action.setText(new))
 
         self.register_data_actions(event_type)
 
@@ -361,11 +369,7 @@ class EventsPlugin(neon_player.Plugin):
             lambda dp, et=event_type: self.set_event_as_export_boundary(dp, et, left=False),
         )
 
-    def _remove_gui_for_event_name(
-        self,
-        event_name: str,
-        remove_add_action: bool = True
-    ) -> None:
+    def _remove_gui_for_event_name(self, event_name: str) -> None:
         timeline = self.get_timeline()
         timeline.remove_timeline_plot(f"Events - {event_name}")
         data_point_actions = [
@@ -384,38 +388,32 @@ class EventsPlugin(neon_player.Plugin):
         timeline.unregister_data_point_action(
             f"Events - {event_name}", f"Delete {event_name} instance"
         )
-        if remove_add_action:
-            self.unregister_timeline_action(f"Add Event/{event_name}")
-            self.app.main_window.remove_menu_if_empty("Timeline/Add Event")
+        self.unregister_timeline_action(f"Add Event/{event_name}")
+        self.app.main_window.remove_menu_if_empty("Timeline/Add Event")
 
-    def add_event_type(self):
+    def create_event_type(self) -> EventType:
         new_event_type = EventType()
         new_event_type.uid = str(uuid.uuid4())
 
+        event_type_counter = 1
         while new_event_type.name == "":
-            candidate_name = f"event-{self._event_type_counter}"
+            candidate_name = f"event-{event_type_counter}"
             if candidate_name not in self._event_types_by_name:
                 new_event_type.name = candidate_name
-            self._event_type_counter += 1
-
-        self._event_types_by_name[new_event_type.name] = new_event_type
-
-        if not self.headless:
-            self._attach_event_type(new_event_type)
-            self._setup_gui_for_event_type(new_event_type)
-            self.changed.emit()
+            event_type_counter += 1
 
         return new_event_type
+
+    def add_event_type(self, event_type: EventType):
+        self._event_types_by_name[event_type.name] = event_type
+        self._update_gui_for_event_types(event_types_to_add=[event_type])
+        self.changed.emit()
 
     def delete_event_type(self, event_type: EventType) -> None:
         del self._events[event_type.uid]
         self.save_cached_json("events.json", self._events)
-
-        if self.headless:
-            return
-
         del self._event_types_by_name[event_type.name]
-        self._remove_gui_for_event_name(event_type.name)
+        self._update_gui_for_event_types(event_types_to_remove=[event_type])
         self.changed.emit()
 
     def add_event(self, event_type: EventType, ts: int | None = None) -> None:
@@ -519,9 +517,15 @@ class EventsPlugin(neon_player.Plugin):
         self._event_types_by_name[new_name] = event_type
         del self._event_types_by_name[old_name]
 
-        self._remove_gui_for_event_name(old_name, remove_add_action=False)
-        self.register_data_actions(event_type)
+        timeline = self.get_timeline()
+        plot_sorting_was_enabled = timeline.disable_plot_sorting()
+
+        self._remove_gui_for_event_name(old_name)
+        self._setup_gui_for_event_type(event_type)
         self._update_timeline_data(event_type)
+
+        if plot_sorting_was_enabled:
+            timeline.enable_plot_sorting()
 
     @action
     @action_params(

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -92,8 +92,8 @@ class EventType(PersistentPropertiesMixin, QObject):
     @staticmethod
     def from_name(name: str) -> "EventType":
         et = EventType()
-        et.name = name
-        et.uid = name if name in IMMUTABLE_EVENTS else str(uuid.uuid4())
+        et._name = name
+        et._uid = name if name in IMMUTABLE_EVENTS else str(uuid.uuid4())
         return et
 
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -59,6 +59,15 @@ class EventType(PersistentPropertiesMixin, QObject):
             return
 
         plugin = EventsPlugin.instance()
+        if plugin is not None and value in IMMUTABLE_EVENTS:
+            QMessageBox.warning(
+                None,
+                "Invalid event name",
+                f"Event cannot be renamed to '{value}' as this name is reserved. "
+                f"Please choose a different name.",
+            )
+            return
+
         if plugin is not None and value in plugin._event_types_by_name:
             QMessageBox.warning(
                 None,

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -521,7 +521,7 @@ class EventsPlugin(neon_player.Plugin):
         if plot_item is None or not plot_item.items:
             return
 
-        x = np.array(self.events.get(event_type.uid, []))
+        x = np.array(self._events.get(event_type.uid, []))
         y = np.zeros_like(x)
         plot_item.items[0].setData(x, y)
 
@@ -626,7 +626,7 @@ class EventsPlugin(neon_player.Plugin):
                 event_types_to_update.append(event_type)
 
         self.save_cached_json("events.json", self._events)
-        if remove_empty_types and event_types_to_remove:
+        if event_types_to_remove:
             self._update_gui_for_event_types(event_types_to_remove=event_types_to_remove)
             self.changed.emit()
         for event_type in event_types_to_update:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -246,7 +246,7 @@ class EventsPlugin(neon_player.Plugin):
         self._event_types_by_name: dict[str, EventType] = {}
         self._events: dict[str, list[int]] = {}
 
-        if self.app is None or self.app.headless:
+        if self.headless:
             return
 
         self.get_timeline().key_pressed.connect(self._on_key_pressed)
@@ -315,7 +315,7 @@ class EventsPlugin(neon_player.Plugin):
         self._update_gui_for_event_types(event_types_to_add=event_types_to_update_ui_for)
 
     def on_disabled(self) -> None:
-        if self.app is None or self.app.headless or self.recording is None:
+        if self.headless or self.recording is None:
             return
 
         event_types = list(self._event_types_by_name.values())
@@ -326,7 +326,7 @@ class EventsPlugin(neon_player.Plugin):
         event_types_to_add: list[EventType] = [],
         event_types_to_remove: list[EventType] = []
     ) -> None:
-        if self.app is None or self.app.headless:
+        if self.headless:
             return
 
         if not event_types_to_add and not event_types_to_remove:
@@ -352,6 +352,9 @@ class EventsPlugin(neon_player.Plugin):
             timeline.enable_plot_sorting()
 
     def _setup_gui_for_event_type(self, event_type: EventType) -> None:
+        if self.headless:
+            return
+
         timeline = self.get_timeline()
         existing_plot = timeline.get_timeline_plot(
             f"Events - {event_type.name}", create_if_not_exists=False
@@ -397,6 +400,9 @@ class EventsPlugin(neon_player.Plugin):
         )
 
     def _remove_gui_for_event_name(self, event_name: str) -> None:
+        if self.headless:
+            return
+
         timeline = self.get_timeline()
         timeline.remove_timeline_plot(f"Events - {event_name}")
         data_point_actions = [

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -613,14 +613,17 @@ class EventsPlugin(neon_player.Plugin):
             existing_timestamps = set(self._events[event_type.uid])
             timestamps_to_remove = set(timestamps)
             remaining_timestamps = existing_timestamps - timestamps_to_remove
-            if not remaining_timestamps:
-                del self._events[event_type.uid]
-                if remove_empty_types:
-                    del self._event_types_by_name[event_name]
-                    event_types_to_remove.append(event_type)
-            else:
+            if remaining_timestamps:
                 self._events[event_type.uid] = list(remaining_timestamps)
-            event_types_to_update.append(event_type)
+                event_types_to_update.append(event_type)
+                continue
+
+            del self._events[event_type.uid]
+            if remove_empty_types:
+                del self._event_types_by_name[event_name]
+                event_types_to_remove.append(event_type)
+            else:
+                event_types_to_update.append(event_type)
 
         self.save_cached_json("events.json", self._events)
         if remove_empty_types and event_types_to_remove:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -91,7 +91,7 @@ class EventType(PersistentPropertiesMixin, QObject):
     def from_name(name: str) -> "EventType":
         et = EventType()
         et.name = name
-        et.uid = str(uuid.uuid4())
+        et.uid = name if name in IMMUTABLE_EVENTS else str(uuid.uuid4())
         return et
 
 
@@ -104,14 +104,13 @@ def _load_events_from_recording(
     for event in recording.events:
         event_name = str(event.event)
 
+        # Look up or create the event type
         et = event_type_cache.get(event_name, None)
         if et is None:
             et = EventType.from_name(event_name)
-            if event_name in IMMUTABLE_EVENTS:
-                et.uid = event_name
             event_type_cache[event_name] = et
 
-        # Add to memory
+        # Add event to the dictionary
         if et.uid not in events:
             events[et.uid] = []
         events[et.uid].append(event.time)
@@ -138,7 +137,6 @@ def _load_events_from_cache(
     known_event_types_by_uid = {et.uid: et for et in known_event_types}
     for event_name in IMMUTABLE_EVENTS:
         et = EventType.from_name(event_name)
-        et.uid = event_name
         known_event_types_by_uid[et.uid] = et
 
     event_type_cache = {}
@@ -213,7 +211,10 @@ class EventsPlugin(neon_player.Plugin):
         # recording. When loading from cache, the event types are loaded
         # beforehand from plugin settings.
         if source == "recording":
-            self.event_types = event_types
+            mutable_event_types = [
+                et for et in event_types if et.name not in IMMUTABLE_EVENTS
+            ]
+            self.event_types = mutable_event_types
             self.save_cached_json("events.json", events)
 
         logging.info(f"Loaded {sum(len(v) for v in self.events.values())} events")

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -218,6 +218,7 @@ def _load_events_from_dataframe(
 
     for name, group in events_df.groupby("name"):
         if name in IMMUTABLE_EVENTS:
+            logging.warning(f"Skipping immutable event '{name}' from imported CSV")
             continue
 
         event_type = event_type_cache.get(name, None)
@@ -300,7 +301,7 @@ class EventsPlugin(neon_player.Plugin):
             # When loading from recording, only mutable event types need to be saved,
             # but the UI needs to be set up for all event types
             mutable_event_types = _filter_event_types(event_types, mutable=True)
-            event_types_to_update_ui_for = event_types
+            event_types_to_setup_ui_for = event_types
             self.event_types = mutable_event_types
             self.save_cached_json("events.json", events)
         elif source == "cache":
@@ -308,11 +309,11 @@ class EventsPlugin(neon_player.Plugin):
             # from plugin settings, so self.event_types is already correct, but the UI
             # still needs to be set up for stored and immutable event types
             immutable_event_types = _filter_event_types(event_types, mutable=False)
-            event_types_to_update_ui_for = self.event_types + immutable_event_types
+            event_types_to_setup_ui_for = self.event_types + immutable_event_types
 
         logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
 
-        self._update_gui_for_event_types(event_types_to_add=event_types_to_update_ui_for)
+        self._update_gui_for_event_types(event_types_to_add=event_types_to_setup_ui_for)
 
     def on_disabled(self) -> None:
         if self.headless or self.recording is None:
@@ -609,16 +610,11 @@ class EventsPlugin(neon_player.Plugin):
 
     def _prepare_events_export(self, recording: NeonRecording, export_window: tuple[int, int]) -> pd.DataFrame:
         start_time, stop_time = export_window
-        event_types_by_uid = self._get_event_types_by_uid()
-        event_names = []
-        for uid in self._events:
-            name = uid if uid in IMMUTABLE_EVENTS else event_types_by_uid[uid].name
-            event_names.append(name)
-
+        events = self.events
         events_df = pd.DataFrame({
             "recording id": recording.info["recording_id"],
-            "timestamp [ns]": list(self._events.values()),
-            "name": event_names,
+            "timestamp [ns]": list(events.values()),
+            "name": list(events.keys()),
         })
 
         events_df = events_df.explode("timestamp [ns]").reset_index(drop=True).dropna()
@@ -637,6 +633,3 @@ class EventsPlugin(neon_player.Plugin):
             if any(row["name"] == matching.event):
                 events_df.loc[index, "type"] = "recording"
         return events_df
-
-    def _get_event_types_by_uid(self) -> dict[str, EventType]:
-        return {et.uid: et for et in self._event_types_by_name.values()}

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -86,7 +86,7 @@ class EventType(PersistentPropertiesMixin, QObject):
         return self._uid
 
     @uid.setter
-    def uid(self, value: str):
+    def uid(self, value: str) -> None:
         self._uid = value
 
     @staticmethod
@@ -100,15 +100,17 @@ class EventType(PersistentPropertiesMixin, QObject):
 class EventTypeListWidget(ValueListWidget):
     @staticmethod
     def from_property_impl(prop: property) -> "EventTypeListWidget":
-        source_params = prop.fget.parameters if hasattr(prop.fget, "parameters") else {}
+        source_params: dict[str, T.Any] = {}
+        if hasattr(prop, "fget") and prop.fget is not None:
+            source_params = prop.fget.parameters if hasattr(prop.fget, "parameters") else {}
 
         return EventTypeListWidget(EventType, source_params)
 
     @staticmethod
     def from_type(cls: type) -> "EventTypeListWidget":
-        return EventTypeListWidget(cls)
+        return EventTypeListWidget(cls, {})
 
-    def on_add_button_clicked(self):
+    def on_add_button_clicked(self) -> None:
         plugin = EventsPlugin.instance()
         if plugin is None:
             return
@@ -117,7 +119,7 @@ class EventTypeListWidget(ValueListWidget):
         plugin.add_event_type(new_event_type)
         self.add_item(new_event_type)
 
-    def remove_item(self, item_widget: ValueListItemWidget):
+    def remove_item(self, item_widget: ValueListItemWidget) -> None:
         plugin = EventsPlugin.instance()
         if plugin is None:
             return
@@ -126,15 +128,12 @@ class EventTypeListWidget(ValueListWidget):
         events = plugin._events.get(event_type.uid, [])
         if events:
             suffix = "" if len(events) == 1 else "s"
-            reply = QMessageBox.question(
-                None,
+            confirmed = plugin.user_confirm(
                 "Confirm event type deletion",
                 f"Deleting event type '{event_type.name}' will also delete its {len(events)}"
                 f" instance{suffix}. Do you want to proceed?",
-                buttons=QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
-                defaultButton=QMessageBox.StandardButton.No,
             )
-            if reply != QMessageBox.StandardButton.Yes:
+            if not confirmed:
                 return
 
         plugin.delete_event_type(event_type)
@@ -143,15 +142,15 @@ class EventTypeListWidget(ValueListWidget):
 
 def _load_events_from_recording(
     recording: NeonRecording, global_event_types: list[str] = []
-) -> tuple[list[EventType], dict]:
+) -> tuple[list[EventType], dict[str, list[int]]]:
     """
     Loads events from the recording and additionally creates event types that
     are defined in global settings.
 
     Returns all created event types and the events as {uid: list of timestamps}.
     """
-    event_type_cache = {}
-    events = {}
+    event_type_cache: dict[str, EventType] = {}
+    events: dict[str, list[int]] = {}
 
     for event in recording.events:
         event_name = str(event.event)

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -154,6 +154,13 @@ def _load_events_from_cache(
     return list(event_type_cache.values()), cached_events
 
 
+def _filter_event_types(event_types: list[EventType], mutable: bool) -> list[EventType]:
+    if mutable:
+        return [et for et in event_types if et.name not in IMMUTABLE_EVENTS]
+    else:
+        return [et for et in event_types if et.name in IMMUTABLE_EVENTS]
+
+
 class EventsPlugin(neon_player.Plugin):
     label = "Events"
     global_properties = EventsPluginGlobalProps()
@@ -207,15 +214,19 @@ class EventsPlugin(neon_player.Plugin):
         event_types, events, source = self._load_events(recording)
         self.events = events
 
-        # NOTE: The event types need to be updated only when loading from the
-        # recording. When loading from cache, the event types are loaded
-        # beforehand from plugin settings.
         if source == "recording":
-            mutable_event_types = [
-                et for et in event_types if et.name not in IMMUTABLE_EVENTS
-            ]
+            # When loading from recording, only mutable event types need to be saved,
+            # but the UI needs to be set up for all event types
+            mutable_event_types = _filter_event_types(event_types, mutable=True)
+            event_types_to_update_ui_for = event_types
             self.event_types = mutable_event_types
             self.save_cached_json("events.json", events)
+        elif source == "cache":
+            # When loading from cache, all event types are expected to have been loaded
+            # from plugin settings, so self.event_types is already correct, but the UI
+            # still needs to be set up for stored and immutable event types
+            immutable_event_types = _filter_event_types(event_types, mutable=False)
+            event_types_to_update_ui_for = self.event_types + immutable_event_types
 
         logging.info(f"Loaded {sum(len(v) for v in self.events.values())} events")
 
@@ -226,7 +237,7 @@ class EventsPlugin(neon_player.Plugin):
         # Disable plot sorting to improve performance for recording with many events
         timeline = self.get_timeline()
         plot_sorting_was_enabled = timeline.disable_plot_sorting()
-        for et in event_types:
+        for et in event_types_to_update_ui_for:
             self._attach_event_type(et)
             self._setup_gui_for_event_type(et)
             self._update_timeline_data(et)
@@ -283,25 +294,23 @@ class EventsPlugin(neon_player.Plugin):
             self.register_data_point_action(
                 f"Events - {event_type.name}",
                 f"Delete {event_type.name} instance",
-                lambda data_point, et=event_type: self.delete_event_instance(
-                    f"Events - {event_type.name}", data_point, et
-                ),
-            )
-            self.register_data_point_action(
-                f"Events - {event_type.name}",
-                f"Set this {event_type.name} as the left export window boundary",
-                lambda dp, et=event_type: self.set_event_as_export_boundary(dp, et, left=True),
-            )
-            self.register_data_point_action(
-                f"Events - {event_type.name}",
-                f"Set this {event_type.name} as the right export window boundary",
-                lambda dp, et=event_type: self.set_event_as_export_boundary(dp, et, left=False),
+                lambda dp, et=event_type: self.delete_event_instance(dp, et),
             )
 
         self.register_data_point_action(
             f"Events - {event_type.name}",
             f"Seek to this {event_type.name}",
             self.seek_to_event_instance,
+        )
+        self.register_data_point_action(
+            f"Events - {event_type.name}",
+            f"Set this {event_type.name} as the left export window boundary",
+            lambda dp, et=event_type: self.set_event_as_export_boundary(dp, et, left=True),
+        )
+        self.register_data_point_action(
+            f"Events - {event_type.name}",
+            f"Set this {event_type.name} as the right export window boundary",
+            lambda dp, et=event_type: self.set_event_as_export_boundary(dp, et, left=False),
         )
 
     def _remove_gui_for_event_name(

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -431,18 +431,29 @@ class EventsPlugin(neon_player.Plugin):
         return new_event_type
 
     def add_event_type(self, event_type: EventType) -> None:
+        if event_type.name in self._event_types_by_name:
+            raise ValueError(
+                f"Event type {event_type.name} already exists."
+            )
+
         self._event_types_by_name[event_type.name] = event_type
         self._update_gui_for_event_types(event_types_to_add=[event_type])
         self.changed.emit()
 
     def delete_event_type(self, event_type: EventType) -> None:
+        if event_type.name in IMMUTABLE_EVENTS:
+            raise ValueError(
+                f"Event type {event_type.name} cannot be deleted."
+            )
+
         if event_type.uid in self._events:
             del self._events[event_type.uid]
             self.save_cached_json("events.json", self._events)
 
-        del self._event_types_by_name[event_type.name]
-        self._update_gui_for_event_types(event_types_to_remove=[event_type])
-        self.changed.emit()
+        if event_type.name in self._event_types_by_name:
+            del self._event_types_by_name[event_type.name]
+            self._update_gui_for_event_types(event_types_to_remove=[event_type])
+            self.changed.emit()
 
     def _add_event(self, event_type: EventType, ts: int | None = None) -> None:
         if self.recording is None:
@@ -472,6 +483,11 @@ class EventsPlugin(neon_player.Plugin):
     def delete_event_instance(
         self, data_point: tuple[int, T.SupportsFloat], event_type: EventType
     ) -> None:
+        if event_type.name in IMMUTABLE_EVENTS:
+            raise ValueError(
+                f"Instances of {event_type.name} event cannot be deleted."
+            )
+
         closest_event = self._find_closest_event(event_type, data_point[0])
         if closest_event is None:
             return
@@ -555,6 +571,11 @@ class EventsPlugin(neon_player.Plugin):
                 self._event_types_by_name[event_name] = event_type
                 event_types_to_add.append(event_type)
             else:
+                if event_type.name in IMMUTABLE_EVENTS:
+                    raise ValueError(
+                        f"Event type {event_type.name} is immutable, new instances "
+                        f"of this event cannot be added."
+                    )
                 event_types_to_update.append(event_type)
 
             if event_type.uid not in self._events:
@@ -563,6 +584,8 @@ class EventsPlugin(neon_player.Plugin):
 
         self.save_cached_json("events.json", self._events)
         self._update_gui_for_event_types(event_types_to_add=event_types_to_add)
+        if event_types_to_add:
+            self.changed.emit()
         for event_type in event_types_to_update:
             self._update_timeline_data(event_type)
 
@@ -578,6 +601,12 @@ class EventsPlugin(neon_player.Plugin):
                 logging.warning(f"Skipping unknown event '{event_name}' from deletion")
                 continue
 
+            if event_name in IMMUTABLE_EVENTS:
+                raise ValueError(
+                    f"Event type {event_name} is immutable, instances "
+                    f"of this event cannot be deleted."
+                )
+
             event_type = self._event_types_by_name[event_name]
             existing_timestamps = set(self._events[event_type.uid])
             timestamps_to_remove = set(timestamps)
@@ -591,6 +620,8 @@ class EventsPlugin(neon_player.Plugin):
 
         self.save_cached_json("events.json", self._events)
         self._update_gui_for_event_types(event_types_to_remove=event_types_to_remove)
+        if event_types_to_remove:
+            self.changed.emit()
         for event_type in event_types_to_update:
             self._update_timeline_data(event_type)
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -18,6 +18,7 @@ from qt_property_widgets.utilities import (
 
 from pupil_labs import neon_player
 from pupil_labs.neon_player import GlobalPluginProperties, action
+from pupil_labs.neon_player.plugins import Plugin
 from pupil_labs.neon_player.ui import HeaderAction
 
 IMMUTABLE_EVENTS = ["recording.begin", "recording.end"]
@@ -169,7 +170,7 @@ class EventsPlugin(neon_player.Plugin):
         super().__init__()
         self._event_types_by_name: dict[str, EventType] = {}
         self._event_type_counter = 1
-        self.events: dict[str, list[int]] = {}
+        self._events: dict[str, list[int]] = {}
 
         if self.headless:
             return
@@ -212,7 +213,7 @@ class EventsPlugin(neon_player.Plugin):
 
     def on_recording_loaded(self, recording: NeonRecording) -> None:  # noqa: C901
         event_types, events, source = self._load_events(recording)
-        self.events = events
+        self._events = events
 
         if source == "recording":
             # When loading from recording, only mutable event types need to be saved,
@@ -228,7 +229,7 @@ class EventsPlugin(neon_player.Plugin):
             immutable_event_types = _filter_event_types(event_types, mutable=False)
             event_types_to_update_ui_for = self.event_types + immutable_event_types
 
-        logging.info(f"Loaded {sum(len(v) for v in self.events.values())} events")
+        logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
 
         if self.headless:
             return
@@ -362,20 +363,20 @@ class EventsPlugin(neon_player.Plugin):
         if ts is None:
             ts = self.app.current_ts
 
-        if event_type.uid not in self.events:
-            self.events[event_type.uid] = []
+        if event_type.uid not in self._events:
+            self._events[event_type.uid] = []
 
-        self.events[event_type.uid].append(ts)
-        self.save_cached_json("events.json", self.events)
+        self._events[event_type.uid].append(ts)
+        self.save_cached_json("events.json", self._events)
         self._update_timeline_data(event_type)
 
     def _find_closest_event(
         self, event_type: EventType, target_ts: int, tolerance_ns: int = 5
     ) -> int | None:
-        if event_type.uid not in self.events:
+        if event_type.uid not in self._events:
             return None
 
-        events_list = self.events[event_type.uid]
+        events_list = self._events[event_type.uid]
         if not events_list:
             return None
 
@@ -388,15 +389,12 @@ class EventsPlugin(neon_player.Plugin):
     def delete_event_instance(
         self, data_point: tuple[int, T.SupportsFloat], event_type: EventType
     ) -> None:
-        if event_type.uid not in self.events:
-            return
-
         closest_event = self._find_closest_event(event_type, data_point[0])
         if closest_event is None:
             return
 
-        self.events[event_type.uid].remove(closest_event)
-        self.save_cached_json("events.json", self.events)
+        self._events[event_type.uid].remove(closest_event)
+        self.save_cached_json("events.json", self._events)
         self._update_timeline_data(event_type)
 
     def seek_to_event_instance(self, data_point: tuple[int, T.SupportsFloat]) -> None:
@@ -444,6 +442,17 @@ class EventsPlugin(neon_player.Plugin):
     def event_types(self, value: list[EventType]) -> None:
         self._event_types_by_name = {et.name: et for et in value}
 
+    @property
+    @property_params(widget=None, dont_encode=True)
+    def events(self) -> dict[str, list[int]]:
+        event_id_name_mapping = {et.uid: et.name for et in self.event_types}
+        events_by_name = {}
+        for event_id, timestamps in self._events.items():
+            # Use IDs as fallback for immutable events that are not included in event_types
+            event_name = event_id_name_mapping.get(event_id, event_id)
+            events_by_name[event_name] = timestamps
+        return events_by_name
+
     def _on_event_name_changed(self, old_name, new_name, event_type) -> None:
         self._event_types_by_name[new_name] = event_type
         del self._event_types_by_name[old_name]
@@ -469,13 +478,13 @@ class EventsPlugin(neon_player.Plugin):
             if event_type is None:
                 event_type = self.create_event_type(name)
 
-            if event_type.uid not in self.events:
-                self.events[event_type.uid] = []
+            if event_type.uid not in self._events:
+                self._events[event_type.uid] = []
 
-            self.events[event_type.uid].extend(group["timestamp [ns]"].tolist())
+            self._events[event_type.uid].extend(group["timestamp [ns]"].tolist())
             modified_types.add(event_type)
 
-        self.save_cached_json("events.json", self.events)
+        self.save_cached_json("events.json", self._events)
 
         for et in modified_types:
             self._update_timeline_data(et)
@@ -495,13 +504,13 @@ class EventsPlugin(neon_player.Plugin):
         start_time, stop_time = export_window
         event_types_by_uid = self._get_event_types_by_uid()
         event_names = []
-        for uid in self.events:
+        for uid in self._events:
             name = uid if uid in IMMUTABLE_EVENTS else event_types_by_uid[uid].name
             event_names.append(name)
 
         events_df = pd.DataFrame({
             "recording id": recording.info["recording_id"],
-            "timestamp [ns]": list(self.events.values()),
+            "timestamp [ns]": list(self._events.values()),
             "name": event_names,
         })
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -483,7 +483,16 @@ class EventsPlugin(neon_player.Plugin):
     @action
     @action_params(compact=True, icon=QIcon(str(neon_player.asset_path("export.svg"))))
     def export(self, destination: Path = Path()):
-        start_time, stop_time = self.app.get_export_window()
+        export_window = self.app.get_export_window()
+        events_df = self._prepare_events_export(self.recording, export_window)
+
+        destination_file = destination / "events.csv"
+        events_df.to_csv(destination_file, index=False)
+
+        logging.info(f"Exported events to {destination_file}")
+
+    def _prepare_events_export(self, recording: NeonRecording, export_window: tuple[int, int]) -> pd.DataFrame:
+        start_time, stop_time = export_window
         event_types_by_uid = self._get_event_types_by_uid()
         event_names = []
         for uid in self.events:
@@ -491,14 +500,14 @@ class EventsPlugin(neon_player.Plugin):
             event_names.append(name)
 
         events_df = pd.DataFrame({
-            "recording id": self.recording.info["recording_id"],
+            "recording id": recording.info["recording_id"],
             "timestamp [ns]": list(self.events.values()),
             "name": event_names,
         })
 
         events_df = events_df.explode("timestamp [ns]").reset_index(drop=True).dropna()
         events_df["timestamp [ns]"] = events_df["timestamp [ns]"].astype(
-            self.recording.events.time.dtype
+            recording.events.time.dtype
         )
         events_df = events_df.sort_values("timestamp [ns]")
         start_mask = events_df["timestamp [ns]"] >= start_time
@@ -507,14 +516,11 @@ class EventsPlugin(neon_player.Plugin):
 
         events_df["type"] = "player"
         for index, row in events_df.iterrows():
-            matching = self.recording.events.sample([row["timestamp [ns]"]])
+            mask = recording.events.time == row["timestamp [ns]"]
+            matching = recording.events[mask]
             if any(row["name"] == matching.event):
                 events_df.loc[index, "type"] = "recording"
-
-        destination_file = destination / "events.csv"
-        events_df.to_csv(destination_file, index=False)
-
-        logging.info(f"Exported events to {destination_file}")
+        return events_df
 
     def _get_event_types_by_uid(self) -> dict[str, EventType]:
         return {et.uid: et for et in self._event_types_by_name.values()}

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -124,6 +124,9 @@ class EventTypeListWidget(ValueListWidget):
         if plugin is None:
             return
 
+        if item_widget.item_widget is None:
+            return
+
         event_type = item_widget.item_widget.value
         events = plugin._events.get(event_type.uid, [])
         if events:
@@ -164,7 +167,7 @@ def _load_events_from_recording(
         # Add event to the dictionary
         if et.uid not in events:
             events[et.uid] = []
-        events[et.uid].append(event.time)
+        events[et.uid].append(int(event.time))
 
     for event_name in global_event_types:
         if event_name in event_type_cache:
@@ -195,12 +198,10 @@ def _load_events_from_cache(
         if uid in event_type_cache:
             continue
 
-        et = known_event_types_by_uid.get(uid, None)
-        if et is not None:
-            event_type_cache[uid] = et
-            continue
+        if uid not in known_event_types_by_uid:
+            raise ValueError(f"Event type with uid {uid} not found")
 
-        raise ValueError(f"Event type with uid {uid} not found")
+        event_type_cache[uid] = known_event_types_by_uid[uid]
 
     return list(event_type_cache.values()), cached_events
 
@@ -208,11 +209,12 @@ def _load_events_from_cache(
 def _load_events_from_dataframe(events_df: pd.DataFrame) -> dict[str, list[int]]:
     events = {}
     for name, group in events_df.groupby("name"):
+        name = str(name)
         if name in IMMUTABLE_EVENTS:
             logging.warning(f"Skipping immutable event '{name}' from imported CSV")
             continue
 
-        events[name] = group["timestamp [ns]"].tolist()
+        events[name] = group["timestamp [ns]"].astype(int).tolist()
 
     return events
 
@@ -246,7 +248,11 @@ class EventsPlugin(neon_player.Plugin):
         if neon_player.instance() is None:
             return None
 
-        return Plugin.get_instance_by_name("EventsPlugin")
+        plugin = Plugin.get_instance_by_name("EventsPlugin")
+        if plugin is not None and not isinstance(plugin, EventsPlugin):
+            raise RuntimeError("Invalid instance of EventsPlugin found")
+
+        return plugin
 
     def _on_key_pressed(self, event: QKeyEvent) -> None:
         key_text = event.text().lower()
@@ -258,8 +264,8 @@ class EventsPlugin(neon_player.Plugin):
                 self._add_event(event_type)
 
     def _load_events(self, recording: NeonRecording) -> tuple[list[EventType], dict, str]:
-        events = {}
-        event_types = []
+        events: dict[str, list[int]] = {}
+        event_types: list[EventType] = []
 
         try:
             cached_events = self.load_cached_json("events.json")
@@ -424,7 +430,7 @@ class EventsPlugin(neon_player.Plugin):
 
         return new_event_type
 
-    def add_event_type(self, event_type: EventType):
+    def add_event_type(self, event_type: EventType) -> None:
         self._event_types_by_name[event_type.name] = event_type
         self._update_gui_for_event_types(event_types_to_add=[event_type])
         self.changed.emit()
@@ -588,7 +594,9 @@ class EventsPlugin(neon_player.Plugin):
         for event_type in event_types_to_update:
             self._update_timeline_data(event_type)
 
-    def _on_event_name_changed(self, old_name, new_name, event_type) -> None:
+    def _on_event_name_changed(
+        self, old_name: str, new_name: str, event_type: EventType
+    ) -> None:
         self._event_types_by_name[new_name] = event_type
         del self._event_types_by_name[old_name]
 
@@ -610,14 +618,14 @@ class EventsPlugin(neon_player.Plugin):
         compact=True,
         icon=QIcon.fromTheme("window-new"),
     )
-    def import_csv(self, source: FilePath):
+    def import_csv(self, source: FilePath) -> None:
         events_df = pd.read_csv(source)
         events = _load_events_from_dataframe(events_df)
         self.add_events(events)
 
     @action
     @action_params(compact=True, icon=QIcon(str(neon_player.asset_path("export.svg"))))
-    def export(self, destination: Path = Path()):
+    def export(self, destination: Path = Path()) -> None:
         export_window = self.app.get_export_window()
         events_df = self._prepare_events_export(self.recording, export_window)
 
@@ -626,7 +634,9 @@ class EventsPlugin(neon_player.Plugin):
 
         logging.info(f"Exported events to {destination_file}")
 
-    def _prepare_events_export(self, recording: NeonRecording, export_window: tuple[int, int]) -> pd.DataFrame:
+    def _prepare_events_export(
+        self, recording: NeonRecording, export_window: tuple[int, int]
+    ) -> pd.DataFrame:
         start_time, stop_time = export_window
         events = self.events
         events_df = pd.DataFrame({

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -17,7 +17,7 @@ from qt_property_widgets.utilities import (
 
 from pupil_labs import neon_player
 from pupil_labs.neon_player import GlobalPluginProperties, action
-from pupil_labs.neon_player.ui import ListPropertyAppenderAction
+from pupil_labs.neon_player.ui import HeaderAction
 
 IMMUTABLE_EVENTS = ["recording.begin", "recording.end"]
 
@@ -115,6 +115,13 @@ def _load_events_from_recording(
 def _load_events_from_cache(
     cached_events: dict, known_event_types: list[EventType]
 ) -> tuple[list[EventType], dict]:
+    """
+    Load event data from a cache stored in events.json. All event types should
+    either be immutable (recording.begin, recording.end) or have been previously
+    defined and stored in the known_event_types list.
+
+    Return event types that are present in the cache as well as events themselves.
+    """
     known_event_types_by_uid = {et.uid: et for et in known_event_types}
     for event_name in IMMUTABLE_EVENTS:
         et = EventType.from_name(event_name)
@@ -122,7 +129,6 @@ def _load_events_from_cache(
         known_event_types_by_uid[et.uid] = et
 
     event_type_cache = {}
-
     for uid in cached_events:
         if uid in event_type_cache:
             continue
@@ -144,15 +150,15 @@ class EventsPlugin(neon_player.Plugin):
     def __init__(self) -> None:
         super().__init__()
         self._event_types_by_name: dict[str, EventType] = {}
+        self._event_type_counter = 1
         self.events: dict[str, list[int]] = {}
-        self.gui_updates_enabled = False
 
         if self.headless:
             return
 
         self.get_timeline().key_pressed.connect(self._on_key_pressed)
-        self.header_action = ListPropertyAppenderAction(
-            "event_types", "+ Add event type"
+        self.header_action = HeaderAction(
+            self.add_event_type, "+ Add event type"
         )
 
     def _on_key_pressed(self, event: QKeyEvent) -> None:
@@ -198,6 +204,8 @@ class EventsPlugin(neon_player.Plugin):
         if self.headless:
             return
 
+        # Create timeline plots for each event type that is present among the events
+        # Disable plot sorting to improve performance for recording with many events
         timeline = self.get_timeline()
         plot_sorting_was_enabled = timeline.disable_plot_sorting()
         for et in event_types:
@@ -265,6 +273,10 @@ class EventsPlugin(neon_player.Plugin):
 
         register_data_actions()
         event_type.name_changed.connect(lambda _, _2: register_data_actions())
+        event_type.name_changed.connect(
+            lambda old, new, et=event_type: self._on_event_name_changed(old, new, et)
+        )
+        event_type.changed.connect(self.changed.emit)
 
     def _remove_gui_for_event_name(
         self,
@@ -292,6 +304,20 @@ class EventsPlugin(neon_player.Plugin):
         if remove_add_action:
             self.unregister_timeline_action(f"Add Event/{event_name}")
             self.app.main_window.remove_menu_if_empty("Timeline/Add Event")
+
+    def add_event_type(self):
+        new_event_type = EventType()
+        new_event_type.uid = str(uuid.uuid4())
+
+        while new_event_type.name == "":
+            candidate_name = f"event-{self._event_type_counter}"
+            if candidate_name not in self._event_types_by_name:
+                new_event_type.name = candidate_name
+            self._event_type_counter += 1
+
+        self._event_types_by_name[new_event_type.name] = new_event_type
+        self._setup_gui_for_event_type(new_event_type)
+        self.changed.emit()
 
     def add_event(self, event_type: EventType, ts: int | None = None) -> None:
         if self.recording is None:
@@ -377,49 +403,7 @@ class EventsPlugin(neon_player.Plugin):
 
     @event_types.setter
     def event_types(self, value: list[EventType]) -> None:
-        new_event_types = []
-        old_event_types = self._event_types_by_name.copy()
-        event_type_counter = 1
-        for event_type in value:
-            if event_type.name in self._event_types_by_name:
-                del old_event_types[event_type.name]
-                continue
-
-            if event_type.uid == "":
-                event_type.uid = str(uuid.uuid4())
-
-            while event_type.name == "":
-                candidate_name = f"event-{event_type_counter}"
-                if candidate_name not in self._event_types_by_name:
-                    event_type.name = candidate_name
-                event_type_counter += 1
-
-            new_event_types.append(event_type)
-            self._event_types_by_name[event_type.name] = event_type
-
-        if self.headless or not self.gui_updates_enabled:
-            return
-
-        timeline = self.get_timeline()
-        plot_sorting_was_enabled = timeline.disable_plot_sorting()
-        for new_event_type in new_event_types:
-            self._setup_gui_for_event_type(new_event_type)
-            new_event_type.changed.connect(self.changed.emit)
-            new_event_type.name_changed.connect(
-                lambda old, new, et=new_event_type: self._on_event_name_changed(
-                    old, new, et
-                )
-            )
-
-        for removed_event_type in old_event_types.values():
-            if removed_event_type.uid in self.events:
-                del self.events[removed_event_type.uid]
-
-            self._remove_gui_for_event_name(removed_event_type.name)
-        self.save_cached_json("events.json", self.events)
-
-        if plot_sorting_was_enabled:
-            timeline.enable_plot_sorting()
+        self._event_types_by_name = {et.name: et for et in value}
 
     def _on_event_name_changed(self, old_name, new_name, event_type) -> None:
         self._remove_gui_for_event_name(old_name, remove_add_action=False)

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -288,9 +288,6 @@ class EventsPlugin(neon_player.Plugin):
         if self.recording is None or self.headless:
             return
 
-        self._events = {}
-        self._event_types_by_name = {}
-
         event_types = list(self._event_types_by_name.values())
         self._update_gui_for_event_types(event_types_to_remove=event_types)
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -74,6 +74,13 @@ class EventType(PersistentPropertiesMixin, QObject):
     def uid(self, value: str):
         self._uid = value
 
+    @staticmethod
+    def from_name(name: str) -> "EventType":
+        et = EventType()
+        et.name = name
+        et.uid = str(uuid.uuid4())
+        return et
+
 
 class EventsPlugin(neon_player.Plugin):
     label = "Events"
@@ -81,7 +88,13 @@ class EventsPlugin(neon_player.Plugin):
 
     def __init__(self) -> None:
         super().__init__()
-        self._event_types: list[EventType] = []
+        self._event_types_by_name: dict[str, EventType] = {}
+        self.events: dict[str, list[int]] = {}
+        self.gui_updates_enabled = False
+
+        if self.headless:
+            return
+
         self.get_timeline().key_pressed.connect(self._on_key_pressed)
         self.header_action = ListPropertyAppenderAction(
             "event_types", "+ Add event type"
@@ -96,87 +109,107 @@ class EventsPlugin(neon_player.Plugin):
             if event_type.shortcut.lower() == key_text:
                 self.add_event(event_type)
 
-    def on_recording_loaded(self, recording: NeonRecording) -> None:  # noqa: C901
-        self.events = {}
+    def _load_events(self, recording: NeonRecording) -> tuple[list[EventType], dict]:
+        events = {}
+        event_types = []
 
         try:
             cached_events = self.load_cached_json("events.json")
         except Exception:
-            logging.exception("Failed to load events json")
+            recording_name = recording._rec_dir.name
+            logging.exception(f"Failed to load events json for {recording_name}")
             cached_events = None
 
-        types_to_update = set()
+        if cached_events is not None:
+            return self._load_events_from_cache(cached_events)
 
-        if cached_events is None:
-            type_cache = {et.name: et for et in self._event_types}
+        event_types, events = self._load_events_from_recording(
+            recording, self.global_properties.global_event_types
+        )
+        self.save_cached_json("events.json", events)
 
-            for event in self.recording.events:
-                evt_name = str(event.event)
+        return event_types, events
 
-                if evt_name in type_cache:
-                    et = type_cache[evt_name]
-                else:
-                    et = self.get_event_type_by_name(evt_name)
-                    if et is None:
-                        et = self.create_event_type(evt_name)
+    @staticmethod
+    def _load_events_from_recording(
+        recording: NeonRecording, global_event_types: list[str] = []
+    ) -> tuple[list[EventType], dict]:
+        event_type_cache = {}
+        events = {}
 
-                    if evt_name in IMMUTABLE_EVENTS:
-                        et.uid = evt_name
+        for event in recording.events:
+            event_name = str(event.event)
 
-                    type_cache[evt_name] = et
-                    types_to_update.add(et)
+            et = event_type_cache.get(event_name, None)
+            if et is None:
+                et = EventType.from_name(event_name)
+                if event_name in IMMUTABLE_EVENTS:
+                    et.uid = event_name
+                event_type_cache[event_name] = et
 
-                # Add to memory
-                if et.uid not in self.events:
-                    self.events[et.uid] = []
-                self.events[et.uid].append(event.time)
+            # Add to memory
+            if et.uid not in events:
+                events[et.uid] = []
+            events[et.uid].append(event.time)
 
-            recording_event_names = list(type_cache.keys())
-            for event_name in self.global_properties.global_event_types:
-                if event_name not in recording_event_names:
-                    self.create_event_type(event_name)
+        for event_name in global_event_types:
+            if event_name in event_type_cache:
+                continue
 
-            self.save_cached_json("events.json", self.events)
+            event_type_cache[event_name] = EventType.from_name(event_name)
 
-        else:
-            self.events = cached_events
-            for uid in self.events:
-                if uid in IMMUTABLE_EVENTS:
-                    et = self.create_event_type(uid)
-                    et.uid = uid
-                else:
-                    et = self.get_event_type(uid)
+        return list(event_type_cache.values()), events
 
-                self._setup_gui_for_event_type(et)
-                types_to_update.add(et)
+    def _load_events_from_cache(
+        self, cached_events: dict
+    ) -> tuple[list[EventType], dict]:
+        known_event_types_by_uid = {
+            et.uid: et for et in self._event_types_by_name.values()
+        }
+        event_type_cache = {}
 
+        for uid in cached_events:
+            if uid in event_type_cache:
+                continue
+
+            et = known_event_types_by_uid.get(uid, None)
+            if et is not None:
+                event_type_cache[uid] = et
+                continue
+
+            raise ValueError(f"Event type with uid {uid} not found")
+
+        return list(event_type_cache.values()), cached_events
+
+    def on_recording_loaded(self, recording: NeonRecording) -> None:  # noqa: C901
+        event_types, events = self._load_events(recording)
+        self.event_types = event_types
+        self.events = events
         logging.info(f"Loaded {sum(len(v) for v in self.events.values())} events")
 
-        timeline = self.get_timeline()
-        timeline.setUpdatesEnabled(False)
-        try:
-            for et in types_to_update:
-                self._setup_gui_for_event_type(et)
-                self._update_timeline_data(et)
-        finally:
-            timeline.setUpdatesEnabled(True)
-            timeline.sort_plots()
-
-    def get_event_type(self, uid: str) -> EventType:
-        for event_type in self._event_types:
-            if event_type.uid == uid:
-                return event_type
-
-        raise ValueError(f"Event type with uid {uid} not found")
-
-    def on_disabled(self) -> None:
-        if self.recording is None:
+        if self.headless:
             return
 
         timeline = self.get_timeline()
+        plot_sorting_was_enabled = timeline.disable_plot_sorting()
+        for et in event_types:
+            self._setup_gui_for_event_type(et)
+            self._update_timeline_data(et)
+        if plot_sorting_was_enabled:
+            timeline.enable_plot_sorting()
+        self.gui_updates_enabled = True
+
+    def on_disabled(self) -> None:
+        if self.recording is None or self.headless:
+            return
+
+        timeline = self.get_timeline()
+        plot_sorting_was_enabled = timeline.disable_plot_sorting()
         timeline.remove_timeline_plot("Events")
-        for et in self._event_types:
-            self._remove_gui_for_event_name(et.name)
+        for event_name in self._event_types_by_name:
+            self._remove_gui_for_event_name(event_name)
+        if plot_sorting_was_enabled:
+            timeline.enable_plot_sorting()
 
     def _setup_gui_for_event_type(self, event_type: EventType) -> None:
         timeline = self.get_timeline()
@@ -332,28 +365,36 @@ class EventsPlugin(neon_player.Plugin):
         primary=True,
     )
     def event_types(self) -> list[EventType]:
-        return self._event_types
+        return list(self._event_types_by_name.values())
 
     @event_types.setter
     def event_types(self, value: list[EventType]) -> None:
-        new_event_types = [
-            event_type for event_type in value if event_type not in self._event_types
-        ]
-        removed_event_types = [
-            event_type for event_type in self._event_types if event_type not in value
-        ]
+        new_event_types = []
+        old_event_types = self._event_types_by_name.copy()
+        event_type_counter = 1
+        for event_type in value:
+            if event_type.name in self._event_types_by_name:
+                del old_event_types[event_type.name]
+                continue
 
-        for new_event_type in new_event_types:
-            if new_event_type.uid == "":
-                new_event_type.uid = str(uuid.uuid4())
+            if event_type.uid == "":
+                event_type.uid = str(uuid.uuid4())
 
-            event_type_counter = 1
-            while new_event_type.name == "":
+            while event_type.name == "":
                 candidate_name = f"event-{event_type_counter}"
-                if candidate_name not in [s.name for s in self._event_types]:
-                    new_event_type.name = candidate_name
+                if candidate_name not in self._event_types_by_name:
+                    event_type.name = candidate_name
                 event_type_counter += 1
 
+            new_event_types.append(event_type)
+            self._event_types_by_name[event_type.name] = event_type
+
+        if self.headless or not self.gui_updates_enabled:
+            return
+
+        timeline = self.get_timeline()
+        plot_sorting_was_enabled = timeline.disable_plot_sorting()
+        for new_event_type in new_event_types:
             self._setup_gui_for_event_type(new_event_type)
             new_event_type.changed.connect(self.changed.emit)
             new_event_type.name_changed.connect(
@@ -362,35 +403,19 @@ class EventsPlugin(neon_player.Plugin):
                 )
             )
 
-        for removed_event_type in removed_event_types:
+        for removed_event_type in old_event_types.values():
             if removed_event_type.uid in self.events:
                 del self.events[removed_event_type.uid]
 
             self._remove_gui_for_event_name(removed_event_type.name)
-            self.save_cached_json("events.json", self.events)
+        self.save_cached_json("events.json", self.events)
 
-        self._event_types = value
+        if plot_sorting_was_enabled:
+            timeline.enable_plot_sorting()
 
     def _on_event_name_changed(self, old_name, new_name, event_type) -> None:
         self._remove_gui_for_event_name(old_name, remove_add_action=False)
         self._update_timeline_data(event_type)
-
-    def create_event_type(self, event_name: str) -> EventType:
-        event_type = EventType()
-        event_type.uid = str(uuid.uuid4())
-        event_type._name = event_name
-
-        if event_name in IMMUTABLE_EVENTS:
-            self._setup_gui_for_event_type(event_type)
-        else:
-            self.event_types = [*self._event_types, event_type]
-
-        return event_type
-
-    def get_event_type_by_name(self, name: str) -> EventType | None:
-        for event_type in self._event_types:
-            if event_type.name == name:
-                return event_type
 
     @action
     @action_params(

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -492,9 +492,7 @@ class EventsPlugin(neon_player.Plugin):
         if closest_event is None:
             return
 
-        self._events[event_type.uid].remove(closest_event)
-        self.save_cached_json("events.json", self._events)
-        self._update_timeline_data(event_type)
+        self.delete_events({event_type.name: [closest_event]})
 
     def seek_to_event_instance(self, data_point: tuple[int, T.SupportsFloat]) -> None:
         self.app.seek_to(data_point[0])
@@ -594,7 +592,6 @@ class EventsPlugin(neon_player.Plugin):
         Delete events specified in the provided dictionary from the existing ones.
         The expected format of the dictionary is {event name: list of timestamps to remove}.
         """
-        event_types_to_remove = []
         event_types_to_update = []
         for event_name, timestamps in events.items():
             if event_name not in self._event_types_by_name:
@@ -613,15 +610,11 @@ class EventsPlugin(neon_player.Plugin):
             remaining_timestamps = existing_timestamps - timestamps_to_remove
             if not remaining_timestamps:
                 del self._events[event_type.uid]
-                event_types_to_remove.append(event_type)
             else:
                 self._events[event_type.uid] = list(remaining_timestamps)
-                event_types_to_update.append(event_type)
+            event_types_to_update.append(event_type)
 
         self.save_cached_json("events.json", self._events)
-        self._update_gui_for_event_types(event_types_to_remove=event_types_to_remove)
-        if event_types_to_remove:
-            self.changed.emit()
         for event_type in event_types_to_update:
             self._update_timeline_data(event_type)
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -444,11 +444,10 @@ class EventsPlugin(neon_player.Plugin):
         self.changed.emit()
 
     def delete_event_type(self, event_type: EventType) -> None:
-        if event_type.uid not in self._events:
-            return
+        if event_type.uid in self._events:
+            del self._events[event_type.uid]
+            self.save_cached_json("events.json", self._events)
 
-        del self._events[event_type.uid]
-        self.save_cached_json("events.json", self._events)
         del self._event_types_by_name[event_type.name]
         self._update_gui_for_event_types(event_types_to_remove=[event_type])
         self.changed.emit()
@@ -554,6 +553,9 @@ class EventsPlugin(neon_player.Plugin):
         self._event_types_by_name[new_name] = event_type
         del self._event_types_by_name[old_name]
 
+        if self.headless:
+            return
+
         timeline = self.get_timeline()
         plot_sorting_was_enabled = timeline.disable_plot_sorting()
 
@@ -571,6 +573,9 @@ class EventsPlugin(neon_player.Plugin):
     )
     def import_csv(self, source: FilePath):
         events_df = pd.read_csv(source)
+        self._import_events_from_dataframe(events_df)
+
+    def _import_events_from_dataframe(self, events_df: pd.DataFrame) -> None:
         event_types, events = _load_events_from_dataframe(
             events_df, self._event_types_by_name
         )

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -15,7 +15,7 @@ from qt_property_widgets.utilities import (
     action_params,
     property_params,
 )
-from qt_property_widgets.widgets import ValueListWidget
+from qt_property_widgets.widgets import ValueListWidget, ValueListItemWidget
 
 from pupil_labs import neon_player
 from pupil_labs.neon_player import GlobalPluginProperties, action
@@ -62,8 +62,8 @@ class EventType(PersistentPropertiesMixin, QObject):
         if plugin is not None and value in plugin._event_types_by_name:
             QMessageBox.warning(
                 None,
-                "Duplicate event type",
-                f"Event type {value} already exists. Please choose a different name.",
+                "Duplicate event name",
+                f"Event '{value}' already exists. Please choose a different name.",
             )
             return
 
@@ -120,6 +120,28 @@ class EventTypeListWidget(ValueListWidget):
         new_event_type = plugin.add_event_type()
         self.add_item(new_event_type)
 
+    def remove_item(self, item_widget: ValueListItemWidget):
+        plugin = EventsPlugin.instance()
+        if plugin is None:
+            return
+
+        event_type = item_widget.item_widget.value
+        events = plugin._events.get(event_type.uid, [])
+        if events:
+            suffix = "" if len(events) == 1 else "s"
+            reply = QMessageBox.question(
+                None,
+                "Confirm event type deletion",
+                f"Deleting event type '{event_type.name}' will also delete its {len(events)}"
+                f" instance{suffix}. Do you want to proceed?",
+                buttons=QMessageBox.StandardButton.Yes | QMessageBox.StandardButton.No,
+                defaultButton=QMessageBox.StandardButton.No,
+            )
+            if reply != QMessageBox.StandardButton.Yes:
+                return
+
+        plugin.delete_event_type(event_type)
+        super().remove_item(item_widget)
 
 def _load_events_from_recording(
     recording: NeonRecording, global_event_types: list[str] = []
@@ -377,11 +399,24 @@ class EventsPlugin(neon_player.Plugin):
             self._event_type_counter += 1
 
         self._event_types_by_name[new_event_type.name] = new_event_type
-        self._attach_event_type(new_event_type)
-        self._setup_gui_for_event_type(new_event_type)
-        self.changed.emit()
+
+        if not self.headless:
+            self._attach_event_type(new_event_type)
+            self._setup_gui_for_event_type(new_event_type)
+            self.changed.emit()
 
         return new_event_type
+
+    def delete_event_type(self, event_type: EventType) -> None:
+        del self._events[event_type.uid]
+        self.save_cached_json("events.json", self._events)
+
+        if self.headless:
+            return
+
+        del self._event_types_by_name[event_type.name]
+        self._remove_gui_for_event_name(event_type.name)
+        self.changed.emit()
 
     def add_event(self, event_type: EventType, ts: int | None = None) -> None:
         if self.recording is None:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -256,7 +256,7 @@ class EventsPlugin(neon_player.Plugin):
 
         for event_type in self._event_types_by_name.values():
             if event_type.shortcut.lower() == key_text:
-                self.add_event(event_type)
+                self._add_event(event_type)
 
     def _load_events(self, recording: NeonRecording) -> tuple[list[EventType], dict, str]:
         events = {}

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -203,6 +203,26 @@ def _load_events_from_cache(
     return list(event_type_cache.values()), cached_events
 
 
+def _load_events_from_dataframe(
+    events_df: pd.DataFrame, existing_event_types: dict[str, EventType]
+) -> tuple[list[EventType], dict]:
+    event_type_cache = {}
+    events = {}
+
+    for name, group in events_df.groupby("name"):
+        if name in IMMUTABLE_EVENTS:
+            continue
+
+        event_type = event_type_cache.get(name, None)
+        if event_type is None:
+            event_type = existing_event_types.get(name, EventType.from_name(name))
+            event_type_cache[event_type.uid] = event_type
+
+        events[event_type.uid] = group["timestamp [ns]"].tolist()
+
+    return list(event_type_cache.values()), events
+
+
 def _filter_event_types(event_types: list[EventType], mutable: bool) -> list[EventType]:
     if mutable:
         return [et for et in event_types if et.name not in IMMUTABLE_EVENTS]
@@ -531,25 +551,30 @@ class EventsPlugin(neon_player.Plugin):
     )
     def import_csv(self, source: FilePath):
         events_df = pd.read_csv(source)
-        modified_types = set()
+        event_types, events = _load_events_from_dataframe(
+            events_df, self._event_types_by_name
+        )
 
-        for name, group in events_df.groupby("name"):
-            if name in IMMUTABLE_EVENTS:
-                continue
+        types_to_add = []
+        types_to_update = []
+        merged_types = {et.name: et for et in self.event_types}
+        for et in event_types:
+            if et.name in self._event_types_by_name:
+                types_to_update.append(et)
+            else:
+                merged_types[et.name] = et
+                types_to_add.append(et)
+        self.event_types = list(merged_types.values())
 
-            event_type = self.get_event_type_by_name(name)
-            if event_type is None:
-                event_type = self.create_event_type(name)
-
-            if event_type.uid not in self._events:
-                self._events[event_type.uid] = []
-
-            self._events[event_type.uid].extend(group["timestamp [ns]"].tolist())
-            modified_types.add(event_type)
+        for event_id, timestamps in events.items():
+            if event_id not in self._events:
+                self._events[event_id] = []
+            self._events[event_id].extend(timestamps)
 
         self.save_cached_json("events.json", self._events)
 
-        for et in modified_types:
+        self._update_gui_for_event_types(event_types_to_add=types_to_add)
+        for et in types_to_update:
             self._update_timeline_data(et)
 
     @action

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -206,29 +206,16 @@ def _load_events_from_cache(
     return list(event_type_cache.values()), cached_events
 
 
-def _load_events_from_dataframe(
-    events_df: pd.DataFrame, existing_event_types: dict[str, EventType]
-) -> tuple[list[EventType], dict]:
-    """
-    Loads events from the provided dataframe, returning all occurring event types
-    and the events as {uid: list of timestamps}.
-    """
-    event_type_cache = {}
+def _load_events_from_dataframe(events_df: pd.DataFrame) -> dict[str, list[int]]:
     events = {}
-
     for name, group in events_df.groupby("name"):
         if name in IMMUTABLE_EVENTS:
             logging.warning(f"Skipping immutable event '{name}' from imported CSV")
             continue
 
-        event_type = event_type_cache.get(name, None)
-        if event_type is None:
-            event_type = existing_event_types.get(name, EventType.from_name(name))
-            event_type_cache[event_type.uid] = event_type
+        events[name] = group["timestamp [ns]"].tolist()
 
-        events[event_type.uid] = group["timestamp [ns]"].tolist()
-
-    return list(event_type_cache.values()), events
+    return events
 
 
 def _filter_event_types(event_types: list[EventType], mutable: bool) -> list[EventType]:
@@ -370,7 +357,7 @@ class EventsPlugin(neon_player.Plugin):
 
         if event_type.name not in IMMUTABLE_EVENTS:
             self.register_timeline_action(
-                f"Add Event/{event_type.name}", None, lambda: self.add_event(event_type)
+                f"Add Event/{event_type.name}", None, lambda: self._add_event(event_type)
             )
             self.app.main_window.sort_action_menu("Timeline/Add Event")
 
@@ -452,19 +439,14 @@ class EventsPlugin(neon_player.Plugin):
         self._update_gui_for_event_types(event_types_to_remove=[event_type])
         self.changed.emit()
 
-    def add_event(self, event_type: EventType, ts: int | None = None) -> None:
+    def _add_event(self, event_type: EventType, ts: int | None = None) -> None:
         if self.recording is None:
             return
 
         if ts is None:
             ts = self.app.current_ts
 
-        if event_type.uid not in self._events:
-            self._events[event_type.uid] = []
-
-        self._events[event_type.uid].append(ts)
-        self.save_cached_json("events.json", self._events)
-        self._update_timeline_data(event_type)
+        self.add_events({event_type.name: [ts]})
 
     def _find_closest_event(
         self, event_type: EventType, target_ts: int, tolerance_ns: int = 5
@@ -541,6 +523,11 @@ class EventsPlugin(neon_player.Plugin):
     @property
     @property_params(widget=None, dont_encode=True)
     def events(self) -> dict[str, list[int]]:
+        """
+        Read-only property that returns the events as a dictionary with event names
+        as keys and lists of all timestamps for each event as values. For modifying
+        events from other plugins, use add_events() and delete_events() methods.
+        """
         event_id_name_mapping = {et.uid: et.name for et in self.event_types}
         events_by_name = {}
         for event_id, timestamps in self._events.items():
@@ -548,6 +535,31 @@ class EventsPlugin(neon_player.Plugin):
             event_name = event_id_name_mapping.get(event_id, event_id)
             events_by_name[event_name] = timestamps
         return events_by_name
+
+    def add_events(self, events: dict[str, list[int]]) -> None:
+        """
+        Add events from the provided dictionary to the existing ones. The expected
+        format of the dictionary is {event name: list of timestamps}.
+        """
+        event_types_to_add = []
+        event_types_to_update = []
+        for event_name, timestamps in events.items():
+            event_type = self._event_types_by_name.get(event_name, None)
+            if event_type is None:
+                event_type = EventType.from_name(event_name)
+                self._event_types_by_name[event_name] = event_type
+                event_types_to_add.append(event_type)
+            else:
+                event_types_to_update.append(event_type)
+
+            if event_type.uid not in self._events:
+                self._events[event_type.uid] = []
+            self._events[event_type.uid].extend(timestamps)
+
+        self.save_cached_json("events.json", self._events)
+        self._update_gui_for_event_types(event_types_to_add=event_types_to_add)
+        for event_type in event_types_to_update:
+            self._update_timeline_data(event_type)
 
     def _on_event_name_changed(self, old_name, new_name, event_type) -> None:
         self._event_types_by_name[new_name] = event_type
@@ -573,34 +585,8 @@ class EventsPlugin(neon_player.Plugin):
     )
     def import_csv(self, source: FilePath):
         events_df = pd.read_csv(source)
-        self._import_events_from_dataframe(events_df)
-
-    def _import_events_from_dataframe(self, events_df: pd.DataFrame) -> None:
-        event_types, events = _load_events_from_dataframe(
-            events_df, self._event_types_by_name
-        )
-
-        types_to_add = []
-        types_to_update = []
-        merged_types = {et.name: et for et in self.event_types}
-        for et in event_types:
-            if et.name in self._event_types_by_name:
-                types_to_update.append(et)
-            else:
-                merged_types[et.name] = et
-                types_to_add.append(et)
-        self.event_types = list(merged_types.values())
-
-        for event_id, timestamps in events.items():
-            if event_id not in self._events:
-                self._events[event_id] = []
-            self._events[event_id].extend(timestamps)
-
-        self.save_cached_json("events.json", self._events)
-
-        self._update_gui_for_event_types(event_types_to_add=types_to_add)
-        for et in types_to_update:
-            self._update_timeline_data(et)
+        events = _load_events_from_dataframe(events_df)
+        self.add_events(events)
 
     @action
     @action_params(compact=True, icon=QIcon(str(neon_player.asset_path("export.svg"))))

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -47,7 +47,6 @@ class EventType(PersistentPropertiesMixin, QObject):
         self._name = ""
         self._shortcut = ""
         self._uid = ""
-        self._plugin = None
 
     @property
     def name(self) -> str:
@@ -58,7 +57,8 @@ class EventType(PersistentPropertiesMixin, QObject):
         if self._name == value:
             return
 
-        if self._plugin is not None and value in self._plugin._event_types_by_name:
+        plugin = EventsPlugin.instance()
+        if plugin is not None and value in plugin._event_types_by_name:
             QMessageBox.warning(
                 None,
                 "Duplicate event type",
@@ -180,6 +180,10 @@ class EventsPlugin(neon_player.Plugin):
             self.add_event_type, "+ Add event type"
         )
 
+    @staticmethod
+    def instance() -> T.Union["EventsPlugin", None]:
+        return Plugin.get_instance_by_name("EventsPlugin")
+
     def _on_key_pressed(self, event: QKeyEvent) -> None:
         key_text = event.text().lower()
         if key_text == "":
@@ -258,10 +262,6 @@ class EventsPlugin(neon_player.Plugin):
             timeline.enable_plot_sorting()
 
     def _attach_event_type(self, event_type: EventType) -> None:
-        # Provide a reference to the plugin for checking whether the new name
-        # of the event type is already taken
-        event_type._plugin = self
-
         # Connect the required signals
         event_type.changed.connect(self.changed.emit)
         event_type.name_changed.connect(

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -82,6 +82,61 @@ class EventType(PersistentPropertiesMixin, QObject):
         return et
 
 
+def _load_events_from_recording(
+    recording: NeonRecording, global_event_types: list[str] = []
+) -> tuple[list[EventType], dict]:
+    event_type_cache = {}
+    events = {}
+
+    for event in recording.events:
+        event_name = str(event.event)
+
+        et = event_type_cache.get(event_name, None)
+        if et is None:
+            et = EventType.from_name(event_name)
+            if event_name in IMMUTABLE_EVENTS:
+                et.uid = event_name
+            event_type_cache[event_name] = et
+
+        # Add to memory
+        if et.uid not in events:
+            events[et.uid] = []
+        events[et.uid].append(event.time)
+
+    for event_name in global_event_types:
+        if event_name in event_type_cache:
+            continue
+
+        event_type_cache[event_name] = EventType.from_name(event_name)
+
+    return list(event_type_cache.values()), events
+
+
+def _load_events_from_cache(
+    cached_events: dict, known_event_types: list[EventType]
+) -> tuple[list[EventType], dict]:
+    known_event_types_by_uid = {et.uid: et for et in known_event_types}
+    for event_name in IMMUTABLE_EVENTS:
+        et = EventType.from_name(event_name)
+        et.uid = event_name
+        known_event_types_by_uid[et.uid] = et
+
+    event_type_cache = {}
+
+    for uid in cached_events:
+        if uid in event_type_cache:
+            continue
+
+        et = known_event_types_by_uid.get(uid, None)
+        if et is not None:
+            event_type_cache[uid] = et
+            continue
+
+        raise ValueError(f"Event type with uid {uid} not found")
+
+    return list(event_type_cache.values()), cached_events
+
+
 class EventsPlugin(neon_player.Plugin):
     label = "Events"
     global_properties = EventsPluginGlobalProps()
@@ -109,7 +164,7 @@ class EventsPlugin(neon_player.Plugin):
             if event_type.shortcut.lower() == key_text:
                 self.add_event(event_type)
 
-    def _load_events(self, recording: NeonRecording) -> tuple[list[EventType], dict]:
+    def _load_events(self, recording: NeonRecording) -> tuple[list[EventType], dict, str]:
         events = {}
         event_types = []
 
@@ -121,70 +176,23 @@ class EventsPlugin(neon_player.Plugin):
             cached_events = None
 
         if cached_events is not None:
-            return self._load_events_from_cache(cached_events)
+            event_types, events = _load_events_from_cache(
+                cached_events, list(self._event_types_by_name.values())
+            )
+            return event_types, events, "cache"
 
-        event_types, events = self._load_events_from_recording(
+        event_types, events = _load_events_from_recording(
             recording, self.global_properties.global_event_types
         )
-        self.save_cached_json("events.json", events)
 
-        return event_types, events
-
-    @staticmethod
-    def _load_events_from_recording(
-        recording: NeonRecording, global_event_types: list[str] = []
-    ) -> tuple[list[EventType], dict]:
-        event_type_cache = {}
-        events = {}
-
-        for event in recording.events:
-            event_name = str(event.event)
-
-            et = event_type_cache.get(event_name, None)
-            if et is None:
-                et = EventType.from_name(event_name)
-                if event_name in IMMUTABLE_EVENTS:
-                    et.uid = event_name
-                event_type_cache[event_name] = et
-
-            # Add to memory
-            if et.uid not in events:
-                events[et.uid] = []
-            events[et.uid].append(event.time)
-
-        for event_name in global_event_types:
-            if event_name in event_type_cache:
-                continue
-
-            event_type_cache[event_name] = EventType.from_name(event_name)
-
-        return list(event_type_cache.values()), events
-
-    def _load_events_from_cache(
-        self, cached_events: dict
-    ) -> tuple[list[EventType], dict]:
-        known_event_types_by_uid = {
-            et.uid: et for et in self._event_types_by_name.values()
-        }
-        event_type_cache = {}
-
-        for uid in cached_events:
-            if uid in event_type_cache:
-                continue
-
-            et = known_event_types_by_uid.get(uid, None)
-            if et is not None:
-                event_type_cache[uid] = et
-                continue
-
-            raise ValueError(f"Event type with uid {uid} not found")
-
-        return list(event_type_cache.values()), cached_events
+        return event_types, events, "recording"
 
     def on_recording_loaded(self, recording: NeonRecording) -> None:  # noqa: C901
-        event_types, events = self._load_events(recording)
-        self.event_types = event_types
+        event_types, events, source = self._load_events(recording)
         self.events = events
+        if source == "recording":
+            self.event_types = event_types
+            self.save_cached_json("events.json", events)
         logging.info(f"Loaded {sum(len(v) for v in self.events.values())} events")
 
         if self.headless:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from pupil_labs.neon_recording import NeonRecording
 from PySide6.QtCore import QObject, Signal
 from PySide6.QtGui import QIcon, QKeyEvent
+from PySide6.QtWidgets import QMessageBox
 from qt_property_widgets.utilities import (
     FilePath,
     PersistentPropertiesMixin,
@@ -45,6 +46,7 @@ class EventType(PersistentPropertiesMixin, QObject):
         self._name = ""
         self._shortcut = ""
         self._uid = ""
+        self._plugin = None
 
     @property
     def name(self) -> str:
@@ -52,6 +54,17 @@ class EventType(PersistentPropertiesMixin, QObject):
 
     @name.setter
     def name(self, value: str) -> None:
+        if self._name == value:
+            return
+
+        if self._plugin is not None and value in self._plugin._event_types_by_name:
+            QMessageBox.warning(
+                None,
+                "Duplicate event type",
+                f"Event type {value} already exists. Please choose a different name.",
+            )
+            return
+
         old_name = self._name
         self._name = value
         self.name_changed.emit(old_name, value)
@@ -116,11 +129,11 @@ def _load_events_from_cache(
     cached_events: dict, known_event_types: list[EventType]
 ) -> tuple[list[EventType], dict]:
     """
-    Load event data from a cache stored in events.json. All event types should
-    either be immutable (recording.begin, recording.end) or have been previously
+    Load event data from a cache stored in events.json. All event types are expected
+    to either be immutable (recording.begin, recording.end) or have been previously
     defined and stored in the known_event_types list.
 
-    Return event types that are present in the cache as well as events themselves.
+    Returns event types that are present in the cache as well as events themselves.
     """
     known_event_types_by_uid = {et.uid: et for et in known_event_types}
     for event_name in IMMUTABLE_EVENTS:
@@ -166,7 +179,7 @@ class EventsPlugin(neon_player.Plugin):
         if key_text == "":
             return
 
-        for event_type in self._event_types:
+        for event_type in self._event_types_by_name.values():
             if event_type.shortcut.lower() == key_text:
                 self.add_event(event_type)
 
@@ -177,8 +190,7 @@ class EventsPlugin(neon_player.Plugin):
         try:
             cached_events = self.load_cached_json("events.json")
         except Exception:
-            recording_name = recording._rec_dir.name
-            logging.exception(f"Failed to load events json for {recording_name}")
+            logging.exception("Failed to load events json")
             cached_events = None
 
         if cached_events is not None:
@@ -196,9 +208,14 @@ class EventsPlugin(neon_player.Plugin):
     def on_recording_loaded(self, recording: NeonRecording) -> None:  # noqa: C901
         event_types, events, source = self._load_events(recording)
         self.events = events
+
+        # NOTE: The event types need to be updated only when loading from the
+        # recording. When loading from cache, the event types are loaded
+        # beforehand from plugin settings.
         if source == "recording":
             self.event_types = event_types
             self.save_cached_json("events.json", events)
+
         logging.info(f"Loaded {sum(len(v) for v in self.events.values())} events")
 
         if self.headless:
@@ -209,11 +226,11 @@ class EventsPlugin(neon_player.Plugin):
         timeline = self.get_timeline()
         plot_sorting_was_enabled = timeline.disable_plot_sorting()
         for et in event_types:
+            self._attach_event_type(et)
             self._setup_gui_for_event_type(et)
             self._update_timeline_data(et)
         if plot_sorting_was_enabled:
             timeline.enable_plot_sorting()
-        self.gui_updates_enabled = True
 
     def on_disabled(self) -> None:
         if self.recording is None or self.headless:
@@ -226,6 +243,17 @@ class EventsPlugin(neon_player.Plugin):
             self._remove_gui_for_event_name(event_name)
         if plot_sorting_was_enabled:
             timeline.enable_plot_sorting()
+
+    def _attach_event_type(self, event_type: EventType) -> None:
+        # Provide a reference to the plugin for checking whether the new name
+        # of the event type is already taken
+        event_type._plugin = self
+
+        # Connect the required signals
+        event_type.changed.connect(self.changed.emit)
+        event_type.name_changed.connect(
+            lambda old, new, et=event_type: self._on_event_name_changed(old, new, et)
+        )
 
     def _setup_gui_for_event_type(self, event_type: EventType) -> None:
         timeline = self.get_timeline()
@@ -247,18 +275,16 @@ class EventsPlugin(neon_player.Plugin):
             self.app.main_window.sort_action_menu("Timeline/Add Event")
             event_type.name_changed.connect(lambda old, new: action.setText(new))
 
-        def register_data_actions():
-            if event_type.name not in IMMUTABLE_EVENTS:
-                self.register_data_point_action(
-                    f"Events - {event_type.name}",
-                    f"Delete {event_type.name} instance",
-                    lambda dp, et=event_type: self.delete_event_instance(dp, et),
-                )
+        self.register_data_actions(event_type)
 
+    def register_data_actions(self, event_type: EventType) -> None:
+        if event_type.name not in IMMUTABLE_EVENTS:
             self.register_data_point_action(
                 f"Events - {event_type.name}",
-                f"Seek to this {event_type.name}",
-                self.seek_to_event_instance,
+                f"Delete {event_type.name} instance",
+                lambda data_point, et=event_type: self.delete_event_instance(
+                    f"Events - {event_type.name}", data_point, et
+                ),
             )
             self.register_data_point_action(
                 f"Events - {event_type.name}",
@@ -271,12 +297,11 @@ class EventsPlugin(neon_player.Plugin):
                 lambda dp, et=event_type: self.set_event_as_export_boundary(dp, et, left=False),
             )
 
-        register_data_actions()
-        event_type.name_changed.connect(lambda _, _2: register_data_actions())
-        event_type.name_changed.connect(
-            lambda old, new, et=event_type: self._on_event_name_changed(old, new, et)
+        self.register_data_point_action(
+            f"Events - {event_type.name}",
+            f"Seek to this {event_type.name}",
+            self.seek_to_event_instance,
         )
-        event_type.changed.connect(self.changed.emit)
 
     def _remove_gui_for_event_name(
         self,
@@ -316,6 +341,7 @@ class EventsPlugin(neon_player.Plugin):
             self._event_type_counter += 1
 
         self._event_types_by_name[new_event_type.name] = new_event_type
+        self._attach_event_type(new_event_type)
         self._setup_gui_for_event_type(new_event_type)
         self.changed.emit()
 
@@ -406,7 +432,11 @@ class EventsPlugin(neon_player.Plugin):
         self._event_types_by_name = {et.name: et for et in value}
 
     def _on_event_name_changed(self, old_name, new_name, event_type) -> None:
+        self._event_types_by_name[new_name] = event_type
+        del self._event_types_by_name[old_name]
+
         self._remove_gui_for_event_name(old_name, remove_add_action=False)
+        self.register_data_actions(event_type)
         self._update_timeline_data(event_type)
 
     @action
@@ -441,9 +471,10 @@ class EventsPlugin(neon_player.Plugin):
     @action_params(compact=True, icon=QIcon(str(neon_player.asset_path("export.svg"))))
     def export(self, destination: Path = Path()):
         start_time, stop_time = self.app.get_export_window()
+        event_types_by_uid = self._get_event_types_by_uid()
         event_names = []
         for uid in self.events:
-            name = uid if uid in IMMUTABLE_EVENTS else self.get_event_type(uid).name
+            name = uid if uid in IMMUTABLE_EVENTS else event_types_by_uid[uid].name
             event_names.append(name)
 
         events_df = pd.DataFrame({
@@ -471,3 +502,6 @@ class EventsPlugin(neon_player.Plugin):
         events_df.to_csv(destination_file, index=False)
 
         logging.info(f"Exported events to {destination_file}")
+
+    def _get_event_types_by_uid(self) -> dict[str, EventType]:
+        return {et.uid: et for et in self._event_types_by_name.values()}

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -15,11 +15,12 @@ from qt_property_widgets.utilities import (
     action_params,
     property_params,
 )
+from qt_property_widgets.widgets import ValueListWidget
 
 from pupil_labs import neon_player
 from pupil_labs.neon_player import GlobalPluginProperties, action
 from pupil_labs.neon_player.plugins import Plugin
-from pupil_labs.neon_player.ui import HeaderAction
+from pupil_labs.neon_player.ui import ListPropertyAppenderAction
 
 IMMUTABLE_EVENTS = ["recording.begin", "recording.end"]
 
@@ -94,6 +95,30 @@ class EventType(PersistentPropertiesMixin, QObject):
         et.name = name
         et.uid = name if name in IMMUTABLE_EVENTS else str(uuid.uuid4())
         return et
+
+
+class EventTypeListWidget(ValueListWidget):
+    @staticmethod
+    def from_property_impl(prop: property) -> "EventTypeListWidget":
+        hints = T.get_type_hints(prop.fget)
+        return_type = hints["return"]
+        item_type = T.get_args(return_type)[0]
+
+        source_params = prop.fget.parameters if hasattr(prop.fget, "parameters") else {}
+
+        return EventTypeListWidget(item_type, source_params)
+
+    @staticmethod
+    def from_type(cls: type) -> "EventTypeListWidget":
+        return EventTypeListWidget(cls)
+
+    def on_add_button_clicked(self):
+        plugin = EventsPlugin.instance()
+        if plugin is None:
+            return
+
+        new_event_type = plugin.add_event_type()
+        self.add_item(new_event_type)
 
 
 def _load_events_from_recording(
@@ -176,8 +201,8 @@ class EventsPlugin(neon_player.Plugin):
             return
 
         self.get_timeline().key_pressed.connect(self._on_key_pressed)
-        self.header_action = HeaderAction(
-            self.add_event_type, "+ Add event type"
+        self.header_action = ListPropertyAppenderAction(
+            "event_types", "+ Add event type"
         )
 
     @staticmethod
@@ -356,6 +381,8 @@ class EventsPlugin(neon_player.Plugin):
         self._setup_gui_for_event_type(new_event_type)
         self.changed.emit()
 
+        return new_event_type
+
     def add_event(self, event_type: EventType, ts: int | None = None) -> None:
         if self.recording is None:
             return
@@ -430,7 +457,7 @@ class EventsPlugin(neon_player.Plugin):
 
     @property
     @property_params(
-        add_button_text="Create new event type",
+        widget=EventTypeListWidget,
         item_params={"label_field": "name"},
         prevent_add=True,
         primary=True,

--- a/src/pupil_labs/neon_player/ui/settings_panel.py
+++ b/src/pupil_labs/neon_player/ui/settings_panel.py
@@ -150,19 +150,24 @@ class SettingsPanel(QScrollArea):
             cls.get_label(), settings_form, not app.loading_recording
         )
         if hasattr(instance, "header_action"):
+            header_action = instance.header_action
+
             tb = QToolButton()
-            tb.setText(instance.header_action.name)
+            tb.setText(header_action.name)
             tb.setCursor(Qt.CursorShape.PointingHandCursor)
-            if isinstance(instance.header_action, ListPropertyAppenderAction):
+            if isinstance(header_action, ListPropertyAppenderAction):
 
                 def do_add():
                     widget = settings_form.property_widgets.get(
-                        instance.header_action.property_name, None
+                        header_action.property_name, None
                     )
                     if widget and hasattr(widget, "on_add_button_clicked"):
                         widget.on_add_button_clicked()
 
-            tb.clicked.connect(lambda _: do_add())
+                tb.clicked.connect(lambda _: do_add())
+
+            else:
+                tb.clicked.connect(header_action.callback)
             tb.setObjectName("HeaderAction")
             expander.controls_layout.addWidget(tb)
 

--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -151,6 +151,7 @@ class TimeLineDock(QWidget):
         app.recording_unloaded.connect(self.on_recording_unloaded)
 
         self.dragging = None
+        self.plot_sorting_enabled = True
 
     def sizeHint(self) -> QSize:
         return QSize(100, 150)
@@ -487,7 +488,8 @@ class TimeLineDock(QWidget):
         if plot_name != "":
             legend.addItem(plot_data_item, plot_name)
 
-        self.sort_plots()
+        if self.plot_sorting_enabled:
+            self.sort_plots()
 
         return plot_item
 
@@ -509,7 +511,8 @@ class TimeLineDock(QWidget):
             self.graphics_layout.removeItem(legend.parentItem())
             del self.timeline_legends[plot_name]
 
-        self.sort_plots()
+        if self.plot_sorting_enabled:
+            self.sort_plots()
 
     def remove_timeline_series(self, plot_name: str, series_name: str):
         if plot_name not in self.timeline_plots:
@@ -620,11 +623,13 @@ class TimeLineDock(QWidget):
             legend = self.timeline_legends[timeline_row_name]
             legend.addItem(bars, name=item_name)
 
-        self.sort_plots()
+        if self.plot_sorting_enabled:
+            self.sort_plots()
 
         return plot_widget
 
     def sort_plots(self) -> None:
+        logging.info("Sorting timeline plots")
         items_to_move = {}
         for move_row in range(self.graphics_layout.currentRow, 1, -1):
             legend = self.graphics_layout.getItem(move_row, 0)
@@ -659,6 +664,15 @@ class TimeLineDock(QWidget):
             self.graphics_layout.addItem(plot, row=row, col=1)
 
         self.fix_scroll_size()
+
+    def enable_plot_sorting(self) -> None:
+        self.plot_sorting_enabled = True
+        self.sort_plots()
+
+    def disable_plot_sorting(self) -> bool:
+        was_enabled = self.plot_sorting_enabled
+        self.plot_sorting_enabled = False
+        return was_enabled
 
     def register_data_point_action(
         self, row_name: str, action_name: str, callback: T.Callable

--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -629,7 +629,6 @@ class TimeLineDock(QWidget):
         return plot_widget
 
     def sort_plots(self) -> None:
-        logging.debug("Sorting timeline plots")
         items_to_move = {}
         for move_row in range(self.graphics_layout.currentRow, 1, -1):
             legend = self.graphics_layout.getItem(move_row, 0)

--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -229,11 +229,11 @@ class TimeLineDock(QWidget):
         for tm in self.trim_markers:
             tm.set_highlighted(self.dragging == tm or tm.nearby(data_pos))
 
-    def on_whitespace_mouse_moved(self, event):
+    def on_whitespace_mouse_moved(self, event) -> None:
         if event.buttons() == Qt.LeftButton:
             self.on_chart_area_clicked(event)
 
-    def on_whitespace_mouse_clicked(self, event):
+    def on_whitespace_mouse_clicked(self, event) -> None:
         if event.button() == Qt.LeftButton:
             self.on_chart_area_clicked(event)
 
@@ -266,7 +266,7 @@ class TimeLineDock(QWidget):
             synth_event = SyntheticEvent(scene_pos, event.globalPos())
             self.check_for_data_item_click(synth_event)
 
-    def on_trim_area_drag_start(self, event: MouseDragEvent):
+    def on_trim_area_drag_start(self, event: MouseDragEvent) -> None:
         app = neon_player.instance()
         if app.recording is None:
             return
@@ -279,7 +279,7 @@ class TimeLineDock(QWidget):
         else:
             self.on_trim_area_dragged(event)
 
-    def on_trim_area_dragged(self, event: MouseDragEvent):
+    def on_trim_area_dragged(self, event: MouseDragEvent) -> None:
         app = neon_player.instance()
         if app.recording is None:
             return
@@ -295,7 +295,7 @@ class TimeLineDock(QWidget):
         app.seek_to(self.dragging.time)
         app.recording_settings.export_window = self.get_export_window()
 
-    def on_trim_area_drag_end(self, event: MouseDragEvent):
+    def on_trim_area_drag_end(self, event: MouseDragEvent) -> None:
         self.dragging = None
         data_pos = self.timestamps_plot.getViewBox().mapSceneToView(event.scenePos())
         for tm in self.trim_markers:
@@ -303,7 +303,7 @@ class TimeLineDock(QWidget):
 
     def on_chart_area_clicked(
         self, event: QGraphicsSceneMouseEvent | MouseClickEvent | MouseDragEvent
-    ):
+    ) -> None:
         app = neon_player.instance()
         if app.recording is None:
             return
@@ -338,14 +338,14 @@ class TimeLineDock(QWidget):
         if event.button() == Qt.RightButton:
             self.check_for_data_item_click(event)
 
-    def check_for_data_item_click(self, event: MouseClickEvent):
+    def check_for_data_item_click(self, event: MouseClickEvent) -> None:
         if event.isAccepted():
             return
 
         nearby_items = self.graphics_layout.scene().itemsNearEvent(event)
         clicked_plot_item = get_clicked_plot_item(nearby_items)
         clicked_data_point = get_clicked_data_point(clicked_plot_item, event)
-        if clicked_data_point is None:
+        if clicked_plot_item is None or clicked_data_point is None:
             self.show_context_menu(QCursor.pos())
             event.accept()
             return
@@ -354,7 +354,7 @@ class TimeLineDock(QWidget):
         self.on_data_point_clicked(row_name, clicked_data_point)
 
     def get_timeline_plot(
-        self, timeline_row_name: str, create_if_missing: bool = False, **kwargs
+        self, timeline_row_name: str, create_if_missing: bool = False
     ) -> pg.PlotItem | None:
         if timeline_row_name in self.timeline_plots:
             return self.timeline_plots[timeline_row_name]
@@ -448,7 +448,7 @@ class TimeLineDock(QWidget):
 
         return plot_item
 
-    def get_timeline_series(self, plot_name: str, series_name: str):
+    def get_timeline_series(self, plot_name: str, series_name: str) -> pg.PlotDataItem | None:
         plot_item = self.get_timeline_plot(plot_name)
         if plot_item is None:
             return None
@@ -457,21 +457,23 @@ class TimeLineDock(QWidget):
             if hasattr(series, "name") and series.name == series_name:
                 return series
 
+        return None
+
     def add_timeline_plot(
         self,
         timeline_row_name: str,
         data: list[tuple[int, T.SupportsFloat]],
         plot_name: str = "",
         color: QColor | None = None,
-        **kwargs,
+        **kwargs: T.Any,
     ) -> pg.PlotDataItem | None:
         app = neon_player.instance()
         if app.recording is None:
-            return
+            return None
 
         plot_item = self.get_timeline_plot(timeline_row_name, True)
         if plot_item is None:
-            return
+            return None
 
         if color is None:
             plot_index = len(plot_item.items)
@@ -493,12 +495,12 @@ class TimeLineDock(QWidget):
 
         return plot_item
 
-    def fix_scroll_size(self):
+    def fix_scroll_size(self) -> None:
         h = sum([p.preferredHeight() for p in self.timeline_plots.values()])
         self.graphics_view.setFixedHeight(h)
         self.playhead.refresh_geometry()
 
-    def remove_timeline_plot(self, plot_name: str):
+    def remove_timeline_plot(self, plot_name: str) -> None:
         plot = self.get_timeline_plot(plot_name)
         if plot is None:
             return
@@ -514,7 +516,7 @@ class TimeLineDock(QWidget):
         if self.plot_sorting_enabled:
             self.sort_plots()
 
-    def remove_timeline_series(self, plot_name: str, series_name: str):
+    def remove_timeline_series(self, plot_name: str, series_name: str) -> None:
         if plot_name not in self.timeline_plots:
             return
 
@@ -553,7 +555,7 @@ class TimeLineDock(QWidget):
         timeline_row_name: str,
         data: list[tuple[int, T.SupportsFloat]],
         plot_name: str = "",
-        **kwargs,
+        **kwargs: T.Any,
     ) -> pg.PlotDataItem | None:
         return self.add_timeline_plot(timeline_row_name, data, plot_name, **kwargs)
 
@@ -575,7 +577,7 @@ class TimeLineDock(QWidget):
         data: list[tuple[int, int, T.SupportsFloat]] | list[tuple[int, int]],
         item_name: str = "",
         color: str = "white",
-    ) -> None:
+    ) -> pg.PlotDataItem | None:
         """Adds a broken bar plot to the timeline where bars are colored based on a Z-value.
 
         Args:
@@ -587,6 +589,9 @@ class TimeLineDock(QWidget):
             color: Name of the pyqtgraph colormap or color(e.g., 'viridis', 'white', ...)
         """
         plot_widget = self.get_timeline_plot(timeline_row_name, True)
+        if plot_widget is None:
+            return None
+
         plot_widget.getViewBox().allow_y_panning = False
         # plot_widget.getViewBox().setMouseEnabled(y=False)
         # plot_widget.setMenuEnabled(False)
@@ -692,7 +697,7 @@ class TimeLineDock(QWidget):
 
         del self.data_point_actions[row_name][action_name]
 
-    def reset_view(self):
+    def reset_view(self) -> None:
         app = neon_player.instance()
         if app.recording is None:
             return
@@ -701,6 +706,7 @@ class TimeLineDock(QWidget):
             padding = 0.7 if plot_item.has_bar else None
             plot_item.getViewBox().autoRange(padding=padding)
 
+        assert self.timestamps_plot is not None
         self.timestamps_plot.getViewBox().setRange(
             xRange=[app.recording.start_time, app.recording.stop_time]
         )

--- a/src/pupil_labs/neon_player/ui/timeline_dock.py
+++ b/src/pupil_labs/neon_player/ui/timeline_dock.py
@@ -629,7 +629,7 @@ class TimeLineDock(QWidget):
         return plot_widget
 
     def sort_plots(self) -> None:
-        logging.info("Sorting timeline plots")
+        logging.debug("Sorting timeline plots")
         items_to_move = {}
         for move_row in range(self.graphics_layout.currentRow, 1, -1):
             legend = self.graphics_layout.getItem(move_row, 0)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,7 +9,7 @@ from pupil_labs.neon_recording.timeseries.events import EventTimeseries
 @pytest.fixture(autouse=False)
 def mock_neon_recording(tmp_path):
     def inner(**kwargs):
-        # Use test folder to initialize mock NeonRecording
+        # Use a temporary folder to initialize mock NeonRecording
         rec = NeonRecording(tmp_path)
 
         # Mock properties of the recording as needed

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -28,6 +28,11 @@ def mock_neon_recording(tmp_path):
 
 
 class MockNeonPlayerApp(QApplication):
+    """
+    Mock NeonPlayerApp to be used in tests that rely on the presence of an application
+    instance. Properties are replaced with ordinary fields that can be set directly
+    before executing the respective test.
+    """
     export_window_changed = Signal(tuple[int, int])
 
     def __init__(self, *args):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,1 +1,21 @@
-"""Configuration for the pytest test suite."""
+import pytest
+
+from pathlib import Path
+from unittest.mock import PropertyMock
+
+from pupil_labs.neon_recording import NeonRecording
+
+
+@pytest.fixture(autouse=False)
+def mock_neon_recording(tmp_path):
+    def inner(**kwargs):
+        # Use test folder to initialize mock NeonRecording
+        rec = NeonRecording(tmp_path)
+
+        # Mock properties of the recording as needed
+        for key, value in kwargs.items():
+            setattr(type(rec), key, PropertyMock(return_value=value))
+
+        return rec
+
+    return inner

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,7 @@
 import pytest
 
+from PySide6.QtCore import Signal
+from PySide6.QtWidgets import QApplication
 from unittest.mock import PropertyMock
 
 from pupil_labs.neon_recording import NeonRecording
@@ -23,3 +25,17 @@ def mock_neon_recording(tmp_path):
         return rec
 
     return inner
+
+
+class MockNeonPlayerApp(QApplication):
+    export_window_changed = Signal(tuple[int, int])
+
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.headless = True
+        self.plugins_by_class = {}
+
+
+@pytest.fixture(scope="session")
+def qapp_cls():
+    return MockNeonPlayerApp

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,9 @@
 import pytest
 
-from pathlib import Path
 from unittest.mock import PropertyMock
 
 from pupil_labs.neon_recording import NeonRecording
+from pupil_labs.neon_recording.timeseries.events import EventTimeseries
 
 
 @pytest.fixture(autouse=False)
@@ -14,7 +14,11 @@ def mock_neon_recording(tmp_path):
 
         # Mock properties of the recording as needed
         for key, value in kwargs.items():
-            setattr(type(rec), key, PropertyMock(return_value=value))
+            mock_value = value.copy()
+            if key == "events":
+                mock_value = EventTimeseries(recording=rec, data=value)
+
+            setattr(type(rec), key, PropertyMock(return_value=mock_value))
 
         return rec
 

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -63,8 +63,8 @@ def test_events__load_events_from_cache():
     event_types = []
     for idx, event_name in enumerate(event_names):
         et = EventType()
-        et.name = event_name
-        et.uid = event_name if "recording" in event_name else f"uid{idx}"
+        et._name = event_name
+        et._uid = event_name if "recording" in event_name else f"uid{idx}"
         event_types.append(et)
 
     cached_events = {

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -7,8 +7,6 @@ from pupil_labs.neon_player.plugins.events import (
 )
 from pupil_labs.neon_recording.timeseries.events import EventArray
 
-from tests.conftest import mock_neon_recording
-
 
 def mock_event_timeseries(events_dict):
     all_events = []

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -1,9 +1,14 @@
-from unittest.mock import MagicMock
-
 import numpy as np
+import pandas as pd
+
+from unittest.mock import MagicMock, patch
 
 from pupil_labs.neon_player.plugins.events import (
-    _load_events_from_cache, _load_events_from_recording, EventType, EventsPlugin
+    _load_events_from_cache,
+    _load_events_from_recording,
+    _load_events_from_dataframe,
+    EventType,
+    EventsPlugin
 )
 from pupil_labs.neon_recording.timeseries.events import EventArray
 
@@ -83,6 +88,28 @@ def test_events__load_events_from_cache():
     assert events == cached_events, "Expected events to match cached events"
 
 
+def test_events__load_events_from_dataframe():
+    events_df = pd.DataFrame({
+        "name": ["recording.begin", "trial.begin", "trial.end", "recording.end"],
+        "timestamp [ns]": [0, 100, 200, 1000],
+    })
+    et_begin = EventType.from_name("trial.begin")
+    event_types, events = _load_events_from_dataframe(events_df, {"trial.begin": et_begin})
+    print(events)
+
+    assert len(event_types) == 2, "Expected only mutable event types to be returned"
+    assert len(events) == 2, "Expected events dict to only contain event of mutable type"
+    for event_name, ts in zip(["trial.begin", "trial.end"], [100, 200]):
+        et = [et for et in event_types if et.name == event_name]
+        assert len(et) == 1, f"Expected exactly one event type for {event_name}, got {len(et)}"
+        et = et[0]
+
+        if event_name == "trial.begin":
+            assert et is et_begin, "Expected existing event type to be used for trial.begin"
+
+        assert events[et.uid] == [ts], f"Wrong timestamp for {event_name}"
+
+
 def test_events_plugin__on_recording_loaded__from_recording(mock_neon_recording):
     et = EventType.from_name("test.event")
 
@@ -111,6 +138,104 @@ def test_events_plugin__on_recording_loaded__from_cache(mock_neon_recording):
     assert plugin.event_types == [], "Expected event types not to be modified"
     assert plugin._events == {et.uid: [100, 200, 300]}, "Expected events to be loaded from cache"
     plugin.save_cached_json.assert_not_called()
+
+
+@patch("pupil_labs.neon_player.plugins.events._load_events_from_dataframe",
+    return_value=(
+        [EventType.from_name("new.event")],
+        {"uid0": [100, 200, 300]},
+    )
+)
+def test_events_plugin__import_csv__adds_new_event_types(mock_load_events_from_dataframe):
+    plugin = EventsPlugin()
+    plugin.save_cached_json = MagicMock()
+
+    # Load function returns mock output so using an empty dataframe
+    plugin._import_events_from_dataframe(pd.DataFrame())
+
+    assert len(plugin.event_types) == 1, "Expected new event type to be added from CSV import"
+    assert plugin.event_types[0].name == "new.event", "Expected event type name to match CSV data"
+    assert plugin._events == {"uid0": [100, 200, 300]}, "Expected events to be loaded from CSV data"
+    plugin.save_cached_json.assert_called_once()
+
+
+def test_events_plugin__import_csv__reuses_existing_event_types():
+    plugin = EventsPlugin()
+    existing_et = EventType.from_name("existing.event")
+    plugin.event_types = [existing_et]
+    plugin._events = {existing_et.uid: [0]}
+    plugin.save_cached_json = MagicMock()
+
+    with patch(
+        "pupil_labs.neon_player.plugins.events._load_events_from_dataframe",
+        return_value=(
+            [existing_et],
+            {existing_et.uid: [100, 200, 300]},
+        )
+    ):
+        # Load function returns mock output so using an empty dataframe for simplicity
+        plugin._import_events_from_dataframe(pd.DataFrame())
+
+    assert len(plugin.event_types) == 1, "Expected existing event type to be reused from CSV import"
+    assert plugin.event_types[0] is existing_et, "Expected existing event type to be reused"
+    assert plugin._events == {existing_et.uid: [0, 100, 200, 300]}, \
+        "Expected events to be appended to the existing ones"
+    plugin.save_cached_json.assert_called_once()
+
+
+def test_events_plugin__create_event_type():
+    plugin = EventsPlugin()
+    et = EventType.from_name("event-1")
+    plugin.event_types = [et]
+    new_et = plugin.create_event_type()
+
+    assert new_et.name == "event-2", "Expected event type to have a unique name"
+
+
+def test_events_plugin__add_event_type():
+    plugin = EventsPlugin()
+    et = EventType.from_name("test.event")
+
+    plugin.add_event_type(et)
+
+    assert et in plugin.event_types, "Expected new event type to be added to event_types list"
+
+
+def test_events_plugin__delete_event_type__no_events():
+    plugin = EventsPlugin()
+    et = EventType.from_name("test.event")
+    plugin.event_types = [et]
+    plugin.delete_event_type(et)
+
+    assert et not in plugin.event_types, "Expected event type to be removed from event_types list"
+
+
+def test_events_plugin__on_event_name_changed():
+    plugin = EventsPlugin()
+    et = EventType.from_name("test.event")
+    plugin.event_types = [et]
+
+    et._name = "renamed.event"
+
+    # Simulate the name_changed signal being emitted
+    plugin._on_event_name_changed("test.event", "renamed.event", et)
+
+    assert "test.event" not in plugin._event_types_by_name
+    assert "renamed.event" in plugin._event_types_by_name
+
+
+def test_events_plugin__delete_event_type__with_events():
+    plugin = EventsPlugin()
+    et = EventType.from_name("test.event")
+    plugin.event_types = [et]
+    plugin._events = {et.uid: [100, 200, 300]}
+    plugin.save_cached_json = MagicMock()
+
+    plugin.delete_event_type(et)
+
+    assert et not in plugin.event_types, "Expected event type to be removed from event_types list"
+    assert et.uid not in plugin._events, "Expected events for deleted type to be removed from events dict"
+    plugin.save_cached_json.assert_called_once()
 
 
 def test_events_plugin__add_event__new_type(mock_neon_recording):

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -1,0 +1,81 @@
+import numpy as np
+
+from pupil_labs.neon_player.plugins.events import (
+    _load_events_from_cache, _load_events_from_recording, EventType
+)
+from pupil_labs.neon_recording.timeseries.events import EventArray
+
+
+def mock_event_timeseries(events_dict):
+    all_events = []
+    for event_name, timestamps in events_dict.items():
+        for ts in timestamps:
+             all_events.append((ts, event_name))
+    all_events = sorted(all_events, key=lambda x: x[0])
+
+    data = np.array([
+        np.void(
+            (ts, event_name),
+            dtype=[("time", np.int64), ("event", np.str_, 50)]
+        )
+        for ts, event_name in all_events
+    ])
+    data = data.view(EventArray)
+
+    return data
+
+
+def test_events__load_events_from_recording(mock_neon_recording):
+    events_dict = {
+        "recording.begin": [0],
+        "trial.begin": [100, 400, 700],
+        "trial.end": [200, 500, 800],
+        "recording.end": [1000],
+    }
+    mock_events = mock_event_timeseries(events_dict)
+    recording = mock_neon_recording(events=mock_events)
+
+    event_types, events = _load_events_from_recording(recording)
+    assert len(event_types) == 4
+    assert len(events) == 4
+
+    for event_name in ["recording.begin", "trial.begin", "trial.end", "recording.end"]:
+        et = [et for et in event_types if et.name == event_name]
+        assert len(et) == 1, f"Expected exactly one event type for {event_name}, got {len(et)}"
+        et = et[0]
+
+        assert et.name == event_name
+        if "recording" in event_name:
+            assert et.uid == event_name, "Expected uid to match name for immutable events"
+
+        assert events[et.uid] == events_dict[event_name], \
+            f"Timestamps for {event_name} do not match input data"
+
+
+def test_events__load_events_from_cache():
+    # Should not contain recording.begin / recording.end as these types are
+    # not stored in the settings file
+    event_names = [
+        "trial.begin", "trial.end", "extra.event"
+    ]
+    event_types = []
+    for idx, event_name in enumerate(event_names):
+        et = EventType()
+        et.name = event_name
+        et.uid = event_name if "recording" in event_name else f"uid{idx}"
+        event_types.append(et)
+
+    cached_events = {
+        "recording.begin": [0],
+        "uid0": [100, 400, 700],  # trial.begin
+        "uid1": [200, 500, 800],  # trial.end
+        "recording.end": [1000],
+    }
+
+    event_types, events = _load_events_from_cache(cached_events, event_types)
+
+    assert len(event_types) == 4
+    for et in event_types:
+        assert et in event_types, f"Expected known event types to be used"
+        assert et.name != "extra.event", "Only present event types should be returned"
+    assert events == cached_events, "Expected events to match cached events"

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -90,24 +90,18 @@ def test_events__load_events_from_cache():
 
 def test_events__load_events_from_dataframe():
     events_df = pd.DataFrame({
-        "name": ["recording.begin", "trial.begin", "trial.end", "recording.end"],
-        "timestamp [ns]": [0, 100, 200, 1000],
+        "name": [
+            "recording.begin", "trial.begin", "trial.end",
+            "trial.begin", "trial.end", "recording.end"
+        ],
+        "timestamp [ns]": [0, 100, 200, 500, 600, 1000],
     })
     et_begin = EventType.from_name("trial.begin")
-    event_types, events = _load_events_from_dataframe(events_df, {"trial.begin": et_begin})
-    print(events)
+    events = _load_events_from_dataframe(events_df)
 
-    assert len(event_types) == 2, "Expected only mutable event types to be returned"
     assert len(events) == 2, "Expected events dict to only contain event of mutable type"
-    for event_name, ts in zip(["trial.begin", "trial.end"], [100, 200]):
-        et = [et for et in event_types if et.name == event_name]
-        assert len(et) == 1, f"Expected exactly one event type for {event_name}, got {len(et)}"
-        et = et[0]
-
-        if event_name == "trial.begin":
-            assert et is et_begin, "Expected existing event type to be used for trial.begin"
-
-        assert events[et.uid] == [ts], f"Wrong timestamp for {event_name}"
+    for event_name, ts in zip(["trial.begin", "trial.end"], [[100, 500], [200, 600]]):
+        assert events[event_name] == ts, f"Wrong timestamp for {event_name}"
 
 
 def test_events_plugin__on_recording_loaded__from_recording(mock_neon_recording):
@@ -140,43 +134,30 @@ def test_events_plugin__on_recording_loaded__from_cache(mock_neon_recording):
     plugin.save_cached_json.assert_not_called()
 
 
-@patch("pupil_labs.neon_player.plugins.events._load_events_from_dataframe",
-    return_value=(
-        [EventType.from_name("new.event")],
-        {"uid0": [100, 200, 300]},
-    )
-)
-def test_events_plugin__import_csv__adds_new_event_types(mock_load_events_from_dataframe):
+def test_events_plugin__add_events__adds_new_event_types():
     plugin = EventsPlugin()
     plugin.save_cached_json = MagicMock()
 
     # Load function returns mock output so using an empty dataframe
-    plugin._import_events_from_dataframe(pd.DataFrame())
+    plugin.add_events({"new.event": [100, 200, 300]})
 
-    assert len(plugin.event_types) == 1, "Expected new event type to be added from CSV import"
-    assert plugin.event_types[0].name == "new.event", "Expected event type name to match CSV data"
-    assert plugin._events == {"uid0": [100, 200, 300]}, "Expected events to be loaded from CSV data"
+    assert len(plugin.event_types) == 1, "Expected new event type to be added"
+    et = plugin.event_types[0]
+    assert et.name == "new.event", "Expected event type name to match the data"
+    assert plugin._events == {et.uid: [100, 200, 300]}, "Expected events to be stored"
     plugin.save_cached_json.assert_called_once()
 
 
-def test_events_plugin__import_csv__reuses_existing_event_types():
+def test_events_plugin__add_events__reuses_existing_event_types():
     plugin = EventsPlugin()
     existing_et = EventType.from_name("existing.event")
     plugin.event_types = [existing_et]
     plugin._events = {existing_et.uid: [0]}
     plugin.save_cached_json = MagicMock()
 
-    with patch(
-        "pupil_labs.neon_player.plugins.events._load_events_from_dataframe",
-        return_value=(
-            [existing_et],
-            {existing_et.uid: [100, 200, 300]},
-        )
-    ):
-        # Load function returns mock output so using an empty dataframe for simplicity
-        plugin._import_events_from_dataframe(pd.DataFrame())
+    plugin.add_events({"existing.event": [100, 200, 300]})
 
-    assert len(plugin.event_types) == 1, "Expected existing event type to be reused from CSV import"
+    assert len(plugin.event_types) == 1, "Expected no new event type to be added"
     assert plugin.event_types[0] is existing_et, "Expected existing event type to be reused"
     assert plugin._events == {existing_et.uid: [0, 100, 200, 300]}, \
         "Expected events to be appended to the existing ones"
@@ -246,7 +227,7 @@ def test_events_plugin__add_event__new_type(mock_neon_recording):
     plugin.event_types = [et]
     plugin._events = {}
 
-    plugin.add_event(et, ts=1)
+    plugin._add_event(et, ts=1)
 
     assert et.uid in plugin._events, "Expected new event type to be added to events dict"
     assert plugin._events[et.uid] == [1], "Expected timestamp to be added to events dict"
@@ -261,7 +242,7 @@ def test_events_plugin__add_event__existing_type(mock_neon_recording):
     plugin.event_types = [et]
     plugin._events = {et.uid: [1, 2, 3]}
 
-    plugin.add_event(et, ts=4)
+    plugin._add_event(et, ts=4)
 
     assert plugin._events[et.uid] == [1, 2, 3, 4], \
         "Expected new timestamp to be appended to existing list"

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -7,6 +7,8 @@ from pupil_labs.neon_player.plugins.events import (
 )
 from pupil_labs.neon_recording.timeseries.events import EventArray
 
+from tests.conftest import mock_neon_recording
+
 
 def mock_event_timeseries(events_dict):
     all_events = []
@@ -83,18 +85,48 @@ def test_events__load_events_from_cache():
     assert events == cached_events, "Expected events to match cached events"
 
 
+def test_events_plugin__on_recording_loaded__from_recording(mock_neon_recording):
+    et = EventType.from_name("test.event")
+
+    plugin = EventsPlugin()
+    plugin._load_events = MagicMock(
+        return_value=([et], {et.uid: [100, 200, 300]}, "recording")
+    )
+    plugin.save_cached_json = MagicMock()
+    plugin.on_recording_loaded(mock_neon_recording())
+
+    assert plugin.event_types == [et], "Expected event types to be loaded from recording"
+    assert plugin._events == {et.uid: [100, 200, 300]}, "Expected events to be loaded from recording"
+    plugin.save_cached_json.assert_called_once()
+
+
+def test_events_plugin__on_recording_loaded__from_cache(mock_neon_recording):
+    et = EventType.from_name("test.event")
+
+    plugin = EventsPlugin()
+    plugin._load_events = MagicMock(
+        return_value=([et], {et.uid: [100, 200, 300]}, "cache")
+    )
+    plugin.save_cached_json = MagicMock()
+    plugin.on_recording_loaded(mock_neon_recording())
+
+    assert plugin.event_types == [], "Expected event types not to be modified"
+    assert plugin._events == {et.uid: [100, 200, 300]}, "Expected events to be loaded from cache"
+    plugin.save_cached_json.assert_not_called()
+
+
 def test_events_plugin__add_event__new_type(mock_neon_recording):
     plugin = EventsPlugin()
     type(plugin).recording = mock_neon_recording()
     plugin.save_cached_json = MagicMock()
     et = EventType.from_name("test.event")
     plugin.event_types = [et]
-    plugin.events = {}
+    plugin._events = {}
 
     plugin.add_event(et, ts=1)
 
-    assert et.uid in plugin.events, "Expected new event type to be added to events dict"
-    assert plugin.events[et.uid] == [1], "Expected timestamp to be added to events dict"
+    assert et.uid in plugin._events, "Expected new event type to be added to events dict"
+    assert plugin._events[et.uid] == [1], "Expected timestamp to be added to events dict"
     plugin.save_cached_json.assert_called_once()
 
 
@@ -104,11 +136,11 @@ def test_events_plugin__add_event__existing_type(mock_neon_recording):
     plugin.save_cached_json = MagicMock()
     et = EventType.from_name("test.event")
     plugin.event_types = [et]
-    plugin.events = {et.uid: [1, 2, 3]}
+    plugin._events = {et.uid: [1, 2, 3]}
 
     plugin.add_event(et, ts=4)
 
-    assert plugin.events[et.uid] == [1, 2, 3, 4], \
+    assert plugin._events[et.uid] == [1, 2, 3, 4], \
         "Expected new timestamp to be appended to existing list"
     plugin.save_cached_json.assert_called_once()
 
@@ -125,7 +157,7 @@ def _prepare_export_tests(mock_neon_recording):
     et_player = EventType.from_name("event.from.player")
     et_same_ts = EventType.from_name("event.same.ts")
     plugin.event_types = [et_rec, et_player, et_same_ts]
-    plugin.events = {
+    plugin._events = {
         "recording.begin": [0],
         et_rec.uid: [100, 400, 700],
         et_player.uid: [200, 500, 800],
@@ -134,6 +166,13 @@ def _prepare_export_tests(mock_neon_recording):
     }
     mock_recording = mock_neon_recording(events=mock_events, info={"recording_id": "test.recording"})
     return plugin, mock_recording
+
+
+def test_events_plugin__events__uses_names_not_ids(mock_neon_recording):
+    plugin, _ = _prepare_export_tests(mock_neon_recording)
+    event_names = ["recording.begin", "event.from.rec", "event.from.player", "event.same.ts", "recording.end"]
+    for event_name in event_names:
+        assert event_name in plugin.events, f"Expected {event_name} to be present in events property"
 
 
 def test_events_plugin__prepare_events_export__whole_time_range(mock_neon_recording):

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -111,3 +111,59 @@ def test_events_plugin__add_event__existing_type(mock_neon_recording):
     assert plugin.events[et.uid] == [1, 2, 3, 4], \
         "Expected new timestamp to be appended to existing list"
     plugin.save_cached_json.assert_called_once()
+
+
+def _prepare_export_tests(mock_neon_recording):
+    plugin = EventsPlugin()
+    mock_events = mock_event_timeseries({
+        "recording.begin": [0],
+        "event.from.rec": [100, 400, 700],
+        "event.same.ts": [100],
+        "recording.end": [1000],
+    })
+    et_rec = EventType.from_name("event.from.rec")
+    et_player = EventType.from_name("event.from.player")
+    et_same_ts = EventType.from_name("event.same.ts")
+    plugin.event_types = [et_rec, et_player, et_same_ts]
+    plugin.events = {
+        "recording.begin": [0],
+        et_rec.uid: [100, 400, 700],
+        et_player.uid: [200, 500, 800],
+        et_same_ts.uid: [100],
+        "recording.end": [1000],
+    }
+    mock_recording = mock_neon_recording(events=mock_events, info={"recording_id": "test.recording"})
+    return plugin, mock_recording
+
+
+def test_events_plugin__prepare_events_export__whole_time_range(mock_neon_recording):
+    plugin, mock_recording = _prepare_export_tests(mock_neon_recording)
+    events_df = plugin._prepare_events_export(mock_recording, export_window=(0, 1000))
+    assert len(events_df) == 9, "Expected all events to be included in export"
+
+
+def test_events_plugin__prepare_events_export__custom_time_range(mock_neon_recording):
+    plugin, mock_recording = _prepare_export_tests(mock_neon_recording)
+    events_df = plugin._prepare_events_export(mock_recording, export_window=(200, 750))
+    assert len(events_df) == 4, "Expected only events within the custom time range to be included in export"
+    for event_to_include in ["event.from.rec", "event.from.player"]:
+        assert len(events_df[events_df["name"] == event_to_include]) == 2, \
+            f"Expected two {event_to_include} events in export"
+
+
+def test_events_plugin__prepare_events_export__timestamps_are_sorted(mock_neon_recording):
+    plugin, mock_recording = _prepare_export_tests(mock_neon_recording)
+    events_df = plugin._prepare_events_export(mock_recording, export_window=(150, 450))
+    assert events_df["name"].tolist() == ["event.from.player", "event.from.rec"], \
+        "Expected events to be sorted by timestamp in export"
+
+
+def test_events_plugin__prepare_events_export__source(mock_neon_recording):
+    plugin, mock_recording = _prepare_export_tests(mock_neon_recording)
+    events_df = plugin._prepare_events_export(mock_recording, export_window=(0, 1000))
+    for event_name, source in zip(
+        ["event.from.rec", "event.from.player", "event.same.ts"],
+        ["recording", "player", "recording"]
+    ):
+        assert all(events_df[events_df["name"] == event_name]["type"] == source), \
+            f"Expected all {event_name} events to be labeled as {source} in export"

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -1,7 +1,9 @@
+from unittest.mock import MagicMock
+
 import numpy as np
 
 from pupil_labs.neon_player.plugins.events import (
-    _load_events_from_cache, _load_events_from_recording, EventType
+    _load_events_from_cache, _load_events_from_recording, EventType, EventsPlugin
 )
 from pupil_labs.neon_recording.timeseries.events import EventArray
 
@@ -79,3 +81,33 @@ def test_events__load_events_from_cache():
         assert et in event_types, f"Expected known event types to be used"
         assert et.name != "extra.event", "Only present event types should be returned"
     assert events == cached_events, "Expected events to match cached events"
+
+
+def test_events_plugin__add_event__new_type(mock_neon_recording):
+    plugin = EventsPlugin()
+    type(plugin).recording = mock_neon_recording()
+    plugin.save_cached_json = MagicMock()
+    et = EventType.from_name("test.event")
+    plugin.event_types = [et]
+    plugin.events = {}
+
+    plugin.add_event(et, ts=1)
+
+    assert et.uid in plugin.events, "Expected new event type to be added to events dict"
+    assert plugin.events[et.uid] == [1], "Expected timestamp to be added to events dict"
+    plugin.save_cached_json.assert_called_once()
+
+
+def test_events_plugin__add_event__existing_type(mock_neon_recording):
+    plugin = EventsPlugin()
+    type(plugin).recording = mock_neon_recording()
+    plugin.save_cached_json = MagicMock()
+    et = EventType.from_name("test.event")
+    plugin.event_types = [et]
+    plugin.events = {et.uid: [1, 2, 3]}
+
+    plugin.add_event(et, ts=4)
+
+    assert plugin.events[et.uid] == [1, 2, 3, 4], \
+        "Expected new timestamp to be appended to existing list"
+    plugin.save_cached_json.assert_called_once()

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -1,6 +1,7 @@
 import numpy as np
 import pandas as pd
 
+import pytest
 from unittest.mock import MagicMock, patch
 
 from pupil_labs.neon_player.plugins.events import (
@@ -134,12 +135,90 @@ def test_events_plugin__on_recording_loaded__from_cache(mock_neon_recording):
     plugin.save_cached_json.assert_not_called()
 
 
-def test_events_plugin__add_events__adds_new_event_types():
+def test_events_plugin__create_event_type():
+    plugin = EventsPlugin()
+    et = EventType.from_name("event-1")
+    plugin.event_types = [et]
+    new_et = plugin.create_event_type()
+
+    assert new_et.name == "event-2", "Expected event type to have a unique name"
+
+
+def test_events_plugin__add_event_type(qtbot):
+    plugin = EventsPlugin()
+    et = EventType.from_name("test.event")
+
+    with qtbot.waitSignal(plugin.changed):
+        plugin.add_event_type(et)
+
+    assert et in plugin.event_types, "Expected new event type to be added to event_types list"
+
+
+def test_events_plugin__add_event_type__type_already_exists():
+    plugin = EventsPlugin()
+    et = EventType.from_name("recording.begin")
+    plugin.event_types = [et]
+
+    with pytest.raises(ValueError, match="already exists"):
+        plugin.add_event_type(et)
+
+
+def test_events_plugin__delete_event_type__no_events(qtbot):
+    plugin = EventsPlugin()
+    et = EventType.from_name("test.event")
+    plugin.event_types = [et]
+
+    with qtbot.waitSignal(plugin.changed):
+        plugin.delete_event_type(et)
+
+    assert et not in plugin.event_types, "Expected event type to be removed from event_types list"
+
+
+def test_events_plugin__delete_event_type__with_events(qtbot):
+    plugin = EventsPlugin()
+    et = EventType.from_name("test.event")
+    plugin.event_types = [et]
+    plugin._events = {et.uid: [100, 200, 300]}
+    plugin.save_cached_json = MagicMock()
+
+    with qtbot.waitSignal(plugin.changed):
+        plugin.delete_event_type(et)
+
+    assert et not in plugin.event_types, "Expected event type to be removed from event_types list"
+    assert et.uid not in plugin._events, "Expected events for deleted type to be removed from events dict"
+    plugin.save_cached_json.assert_called_once()
+
+
+def test_events_plugin__delete_event_type__immutable_type():
+    plugin = EventsPlugin()
+    et = EventType.from_name("recording.begin")
+    plugin.event_types = [et]
+
+    with pytest.raises(ValueError, match="cannot be deleted"):
+        plugin.delete_event_type(et)
+
+
+def test_events_plugin__on_event_name_changed():
+    plugin = EventsPlugin()
+    et = EventType.from_name("test.event")
+    plugin.event_types = [et]
+
+    et._name = "renamed.event"
+
+    # Simulate the name_changed signal being emitted
+    plugin._on_event_name_changed("test.event", "renamed.event", et)
+
+    assert "test.event" not in plugin._event_types_by_name
+    assert "renamed.event" in plugin._event_types_by_name
+
+
+def test_events_plugin__add_events__adds_new_event_types(qtbot):
     plugin = EventsPlugin()
     plugin.save_cached_json = MagicMock()
 
     # Load function returns mock output so using an empty dataframe
-    plugin.add_events({"new.event": [100, 200, 300]})
+    with qtbot.waitSignal(plugin.changed):
+        plugin.add_events({"new.event": [100, 200, 300]})
 
     assert len(plugin.event_types) == 1, "Expected new event type to be added"
     et = plugin.event_types[0]
@@ -164,92 +243,26 @@ def test_events_plugin__add_events__reuses_existing_event_types():
     plugin.save_cached_json.assert_called_once()
 
 
-def test_events_plugin__create_event_type():
+def test_events_plugin__add_events__raises_on_immutable_type():
     plugin = EventsPlugin()
-    et = EventType.from_name("event-1")
-    plugin.event_types = [et]
-    new_et = plugin.create_event_type()
-
-    assert new_et.name == "event-2", "Expected event type to have a unique name"
-
-
-def test_events_plugin__add_event_type():
-    plugin = EventsPlugin()
-    et = EventType.from_name("test.event")
-
-    plugin.add_event_type(et)
-
-    assert et in plugin.event_types, "Expected new event type to be added to event_types list"
-
-
-def test_events_plugin__delete_event_type__no_events():
-    plugin = EventsPlugin()
-    et = EventType.from_name("test.event")
-    plugin.event_types = [et]
-    plugin.delete_event_type(et)
-
-    assert et not in plugin.event_types, "Expected event type to be removed from event_types list"
-
-
-def test_events_plugin__on_event_name_changed():
-    plugin = EventsPlugin()
-    et = EventType.from_name("test.event")
+    et = EventType.from_name("recording.begin")
     plugin.event_types = [et]
 
-    et._name = "renamed.event"
-
-    # Simulate the name_changed signal being emitted
-    plugin._on_event_name_changed("test.event", "renamed.event", et)
-
-    assert "test.event" not in plugin._event_types_by_name
-    assert "renamed.event" in plugin._event_types_by_name
+    with pytest.raises(ValueError, match="cannot be added"):
+        plugin.add_events({"recording.begin": [100, 200]})
 
 
-def test_events_plugin__delete_event_type__with_events():
+def test_events_plugin__delete_events__raises_on_immutable_type():
     plugin = EventsPlugin()
-    et = EventType.from_name("test.event")
+    et = EventType.from_name("recording.begin")
     plugin.event_types = [et]
-    plugin._events = {et.uid: [100, 200, 300]}
-    plugin.save_cached_json = MagicMock()
+    plugin._events = {"recording.begin": [0]}
 
-    plugin.delete_event_type(et)
-
-    assert et not in plugin.event_types, "Expected event type to be removed from event_types list"
-    assert et.uid not in plugin._events, "Expected events for deleted type to be removed from events dict"
-    plugin.save_cached_json.assert_called_once()
+    with pytest.raises(ValueError, match="cannot be deleted"):
+        plugin.delete_events({"recording.begin": [0]})
 
 
-def test_events_plugin__add_event__new_type(mock_neon_recording):
-    plugin = EventsPlugin()
-    type(plugin).recording = mock_neon_recording()
-    plugin.save_cached_json = MagicMock()
-    et = EventType.from_name("test.event")
-    plugin.event_types = [et]
-    plugin._events = {}
-
-    plugin._add_event(et, ts=1)
-
-    assert et.uid in plugin._events, "Expected new event type to be added to events dict"
-    assert plugin._events[et.uid] == [1], "Expected timestamp to be added to events dict"
-    plugin.save_cached_json.assert_called_once()
-
-
-def test_events_plugin__add_event__existing_type(mock_neon_recording):
-    plugin = EventsPlugin()
-    type(plugin).recording = mock_neon_recording()
-    plugin.save_cached_json = MagicMock()
-    et = EventType.from_name("test.event")
-    plugin.event_types = [et]
-    plugin._events = {et.uid: [1, 2, 3]}
-
-    plugin._add_event(et, ts=4)
-
-    assert plugin._events[et.uid] == [1, 2, 3, 4], \
-        "Expected new timestamp to be appended to existing list"
-    plugin.save_cached_json.assert_called_once()
-
-
-def _prepare_export_tests(mock_neon_recording):
+def _prepare_test_data(mock_neon_recording):
     plugin = EventsPlugin()
     mock_events = mock_event_timeseries({
         "recording.begin": [0],
@@ -272,21 +285,39 @@ def _prepare_export_tests(mock_neon_recording):
     return plugin, mock_recording
 
 
+def test_events_plugin__find_closest_event(mock_neon_recording):
+    plugin, _ = _prepare_test_data(mock_neon_recording)
+    et = plugin._event_types_by_name["event.from.rec"]
+    assert plugin._find_closest_event(et, 100) == 100
+
+
+def test_events_plugin__find_closest_event__missing_type(mock_neon_recording):
+    plugin, _ = _prepare_test_data(mock_neon_recording)
+    et = EventType.from_name("non.existent.event")
+    assert plugin._find_closest_event(et, 100) is None
+
+
+def test_events_plugin__find_closest_event__tolerance(mock_neon_recording):
+    plugin, _ = _prepare_test_data(mock_neon_recording)
+    et = plugin._event_types_by_name["event.from.rec"]
+    assert plugin._find_closest_event(et, 110, tolerance_ns=15) == 100
+
+
 def test_events_plugin__events__uses_names_not_ids(mock_neon_recording):
-    plugin, _ = _prepare_export_tests(mock_neon_recording)
+    plugin, _ = _prepare_test_data(mock_neon_recording)
     event_names = ["recording.begin", "event.from.rec", "event.from.player", "event.same.ts", "recording.end"]
     for event_name in event_names:
         assert event_name in plugin.events, f"Expected {event_name} to be present in events property"
 
 
 def test_events_plugin__prepare_events_export__whole_time_range(mock_neon_recording):
-    plugin, mock_recording = _prepare_export_tests(mock_neon_recording)
+    plugin, mock_recording = _prepare_test_data(mock_neon_recording)
     events_df = plugin._prepare_events_export(mock_recording, export_window=(0, 1000))
     assert len(events_df) == 9, "Expected all events to be included in export"
 
 
 def test_events_plugin__prepare_events_export__custom_time_range(mock_neon_recording):
-    plugin, mock_recording = _prepare_export_tests(mock_neon_recording)
+    plugin, mock_recording = _prepare_test_data(mock_neon_recording)
     events_df = plugin._prepare_events_export(mock_recording, export_window=(200, 750))
     assert len(events_df) == 4, "Expected only events within the custom time range to be included in export"
     for event_to_include in ["event.from.rec", "event.from.player"]:
@@ -295,14 +326,14 @@ def test_events_plugin__prepare_events_export__custom_time_range(mock_neon_recor
 
 
 def test_events_plugin__prepare_events_export__timestamps_are_sorted(mock_neon_recording):
-    plugin, mock_recording = _prepare_export_tests(mock_neon_recording)
+    plugin, mock_recording = _prepare_test_data(mock_neon_recording)
     events_df = plugin._prepare_events_export(mock_recording, export_window=(150, 450))
     assert events_df["name"].tolist() == ["event.from.player", "event.from.rec"], \
         "Expected events to be sorted by timestamp in export"
 
 
 def test_events_plugin__prepare_events_export__source(mock_neon_recording):
-    plugin, mock_recording = _prepare_export_tests(mock_neon_recording)
+    plugin, mock_recording = _prepare_test_data(mock_neon_recording)
     events_df = plugin._prepare_events_export(mock_recording, export_window=(0, 1000))
     for event_name, source in zip(
         ["event.from.rec", "event.from.player", "event.same.ts"],

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -252,6 +252,37 @@ def test_events_plugin__add_events__raises_on_immutable_type():
         plugin.add_events({"recording.begin": [100, 200]})
 
 
+def test_events_plugin__delete_events__deletes_events():
+    plugin = EventsPlugin()
+    et = EventType.from_name("test.event")
+    plugin.event_types = [et]
+    plugin._events = {et.uid: [100, 200, 300, 400]}
+    plugin.save_cached_json = MagicMock()
+
+    plugin.delete_events({"test.event": [200, 300]})
+
+    assert sorted(plugin._events[et.uid]) == [100, 400], \
+        "Expected specified events to be deleted"
+    plugin.save_cached_json.assert_called_once()
+
+
+def test_events_plugin__delete_events__removes_event_type_if_no_events_left(qtbot):
+    plugin = EventsPlugin()
+    et = EventType.from_name("test.event")
+    plugin.event_types = [et]
+    plugin._events = {et.uid: [100, 200]}
+    plugin.save_cached_json = MagicMock()
+
+    with qtbot.waitSignal(plugin.changed):
+        plugin.delete_events({"test.event": [100, 200]}, remove_empty_types=True)
+
+    assert et.name not in plugin._event_types_by_name, \
+        "Expected event type to be removed from event_types_by_name dict"
+    assert et.uid not in plugin._events, \
+        "Expected events for deleted type to be removed from events dict"
+    plugin.save_cached_json.assert_called_once()
+
+
 def test_events_plugin__delete_events__raises_on_immutable_type():
     plugin = EventsPlugin()
     et = EventType.from_name("recording.begin")

--- a/tests/test_plugins/test_surface_tracking/test_tracked_surface.py
+++ b/tests/test_plugins/test_surface_tracking/test_tracked_surface.py
@@ -4,6 +4,7 @@ import pytest
 
 from unittest.mock import MagicMock
 
+from pupil_labs.neon_player.plugins.gaze import GazeDataPlugin
 from pupil_labs.neon_player.plugins.surface_tracking.tracked_surface import TrackedSurface
 from pupil_labs.neon_recording.timeseries.gaze import GazeTimeseries, GazeArray
 
@@ -20,11 +21,13 @@ def mock_gaze_timeseries(time, point_x, point_y):
     return GazeTimeseries("", data=data)
 
 
-def _prepare_test_data():
+def _prepare_test_data(qapp):
     """
     Five fixations with two gaze samples each, only the first two are mapped to
     the surface (see side effect of the mocked method).
     """
+    # Tracked surface requires gaze plugin to be present for tracking changes in offset
+    qapp.plugins_by_class["GazeDataPlugin"] = GazeDataPlugin()
 
     surface = TrackedSurface()
     gazes = mock_gaze_timeseries(
@@ -57,8 +60,8 @@ def _prepare_test_data():
     return surface, gazes, fixation_data
 
 
-def test_tracked_surface_append_mapped_fixation_data_gaze_samples_forwarded():
-    surface, gazes, fixation_data = _prepare_test_data()
+def test_tracked_surface_append_mapped_fixation_data_gaze_samples_forwarded(qapp):
+    surface, gazes, fixation_data = _prepare_test_data(qapp)
     result = surface._append_mapped_fixation_data(gazes, fixation_data.copy())
 
     for idx, mock_call in enumerate(surface.apply_offset_and_map_gazes.call_args_list):
@@ -72,8 +75,8 @@ def test_tracked_surface_append_mapped_fixation_data_gaze_samples_forwarded():
 
 
 @pytest.mark.parametrize("fixation_id", [1, 2])
-def test_tracked_surface_append_mapped_fixation_data_fixation_should_be_mapped(fixation_id):
-    surface, gazes, fixation_data = _prepare_test_data()
+def test_tracked_surface_append_mapped_fixation_data_fixation_should_be_mapped(qapp, fixation_id):
+    surface, gazes, fixation_data = _prepare_test_data(qapp)
     result = surface._append_mapped_fixation_data(gazes, fixation_data.copy())
 
     fixation_row = result[result["fixation id"] == fixation_id]
@@ -83,8 +86,8 @@ def test_tracked_surface_append_mapped_fixation_data_fixation_should_be_mapped(f
 
 
 @pytest.mark.parametrize("fixation_id", [3, 4])
-def test_tracked_surface_append_mapped_fixation_data_fixation_should_not_be_mapped(fixation_id):
-    surface, gazes, fixation_data = _prepare_test_data()
+def test_tracked_surface_append_mapped_fixation_data_fixation_should_not_be_mapped(qapp, fixation_id):
+    surface, gazes, fixation_data = _prepare_test_data(qapp)
     result = surface._append_mapped_fixation_data(gazes, fixation_data.copy())
 
     fixation_row = result[result["fixation id"] == fixation_id]
@@ -94,8 +97,8 @@ def test_tracked_surface_append_mapped_fixation_data_fixation_should_not_be_mapp
 
 
 @pytest.mark.parametrize("fixation_id", [5])
-def test_tracked_surface_append_mapped_fixation_data_fixation_no_mapped_gazes(fixation_id):
-    surface, gazes, fixation_data = _prepare_test_data()
+def test_tracked_surface_append_mapped_fixation_data_fixation_no_mapped_gazes(qapp, fixation_id):
+    surface, gazes, fixation_data = _prepare_test_data(qapp)
     result = surface._append_mapped_fixation_data(gazes, fixation_data.copy())
 
     fixation_row = result[result["fixation id"] == fixation_id]

--- a/uv.lock
+++ b/uv.lock
@@ -1130,6 +1130,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pandas-stubs"
+version = "3.0.3.260530"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3d/aa/c41a8a0ff86fd85dbb3ec0c1f3fa488ca64a8b5f82654ae1b07d84acefe5/pandas_stubs-3.0.3.260530.tar.gz", hash = "sha256:d1efe47b2e5a312c047d7feabec5cb7a55365747983420077e9fcbe9ab74f714", size = 113183, upload-time = "2026-05-30T17:47:40.34Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0b/e0/99ec5b02203c4e9ce878bc63d8caa06ac1f891e4d63bded9a5ced70fcb4f/pandas_stubs-3.0.3.260530-py3-none-any.whl", hash = "sha256:a6277eb1c8cebf48d9b2413fcd2e9a6b4ff479c934a223c29eacbc3058c4cb55", size = 173780, upload-time = "2026-05-30T17:47:39.13Z" },
+]
+
+[[package]]
 name = "pathlib-abc"
 version = "0.5.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1307,6 +1319,7 @@ dev = [
     { name = "mkdocs-minify-plugin" },
     { name = "mkdocstrings", extra = ["python"] },
     { name = "mypy" },
+    { name = "pandas-stubs" },
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
@@ -1353,6 +1366,7 @@ dev = [
     { name = "mkdocs-minify-plugin", specifier = ">=0.8" },
     { name = "mkdocstrings", extras = ["python"], specifier = ">=0.25" },
     { name = "mypy", specifier = ">=0.991" },
+    { name = "pandas-stubs", specifier = ">=3.0.3.260530" },
     { name = "pre-commit", specifier = ">=2.20.0" },
     { name = "pytest", specifier = ">=8.2" },
     { name = "pytest-cov", specifier = ">=4.0.0" },

--- a/uv.lock
+++ b/uv.lock
@@ -1310,6 +1310,7 @@ dev = [
     { name = "pre-commit" },
     { name = "pytest" },
     { name = "pytest-cov" },
+    { name = "pytest-qt" },
     { name = "tox-uv" },
 ]
 
@@ -1355,6 +1356,7 @@ dev = [
     { name = "pre-commit", specifier = ">=2.20.0" },
     { name = "pytest", specifier = ">=8.2" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
+    { name = "pytest-qt", specifier = ">=4.5.0" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "tox-uv", specifier = ">=1.11.3" },
 ]
@@ -4308,6 +4310,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
+]
+
+[[package]]
+name = "pytest-qt"
+version = "4.5.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pluggy" },
+    { name = "pytest" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/61/8bdec02663c18bf5016709b909411dce04a868710477dc9b9844ffcf8dd2/pytest_qt-4.5.0.tar.gz", hash = "sha256:51620e01c488f065d2036425cbc1cbcf8a6972295105fd285321eb47e66a319f", size = 128702, upload-time = "2025-07-01T17:24:39.889Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cc/d0/8339b888ad64a3d4e508fed8245a402b503846e1972c10ad60955883dcbb/pytest_qt-4.5.0-py3-none-any.whl", hash = "sha256:ed21ea9b861247f7d18090a26bfbda8fb51d7a8a7b6f776157426ff2ccf26eff", size = 37214, upload-time = "2025-07-01T17:24:38.226Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Changes visible to the user:

- faster loading of recs with many events
- it is no longer possible to set duplicate names for events from the UI, an error alert is shown, the renaming is reverted to the last valid state  
  <img width="844" height="276" alt="image" src="https://github.com/user-attachments/assets/5f04ca77-751e-4ca1-a50d-9d6aad5b2145" />

- added a dialog for confirming that an event type should be deleted in case events of this type exist
  <img width="846" height="284" alt="image" src="https://github.com/user-attachments/assets/d9f87a4d-8406-4062-bf08-8cab24c5f43b" />

- fixes a minor bug with export: if several recording events had the exact same timestamp, only one of them would previously be shown as coming from the recording, the rest were shown to be added in the player

Changes visible to the plugin developer:

- read-only `EventsPlugin().events` property that returns a dict `{event_name: timestamps}`, thereby obscuring the IDs and allowing to get the list of all events that exist

Changes to the internal implementation:

- control flow is reworked to create timeline plots only in `on_recording_loaded` when loading a recording. Previously, it could happen during `__setstate__` or `create_event_type` depending on where the information comes from
- disable sorting of timeline plots while loading and unloading many events
- event types are internally stored in a dictionary `self._event_types_by_name`, but only values of this dict are exposed for the widget
- events are internally stored in `self._events`, which should not be modified from outside

Interactions to test:

- plugin lifecycle
   - [x] loading events from the recording (opening for the first time)
   - [x] loading events from cache (re-opening)
   - [x] importing events from CSV
   - [x] exporting events to CSV 
- event type lifecycle
   - [x] adding an event type (sidebar, timeline plot, add event action, settings are saved)
   - [x] renaming an event type: valid name (plots are updated, settings are saved)
   - [x] renaming an event type: invalid name (alert is shown, changes declined)
   - [x] deleting an event type: no events exist (delete from sidebar, timeline, and settings)
   - [x] deleting an event type: events exist (prompt for confirmation, delete as above if yes)
- event lifecycle
   - [x] adding an event via right-click
   - [x] adding an event via shortcut
   - [x] deleting an event
   - [x] check actions accessible after a right-click on an event (immutable / mutable)