### PR TITLE
fix(audio): ensure consistency of stream params across encoded frames

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -63,6 +63,7 @@ dev-dependencies = [
     "pytest-cov>=4.0.0",
     # stubs
     "pandas-stubs>=3.0.3.260530",
+    "scipy-stubs>=1.17.1.5",
     # "opencv-stubs",
     # "types-protobuf",
     # docs

--- a/src/pupil_labs/neon_player/plugins/audio.py
+++ b/src/pupil_labs/neon_player/plugins/audio.py
@@ -1,5 +1,8 @@
 import av
+import fractions
 import numpy as np
+import typing as T
+
 from PySide6.QtCore import QSize, Qt, QTimer, QUrl
 from PySide6.QtGui import QPixmap
 from PySide6.QtMultimedia import QAudioOutput, QMediaPlayer
@@ -16,6 +19,22 @@ from pupil_labs import neon_player
 from pupil_labs.neon_player.job_manager import ProgressUpdate
 from pupil_labs.neon_recording import NeonRecording
 from pupil_labs.video.reader import StreamNotFound
+
+
+def _prepare_audio_frame(
+    audio_data: np.ndarray, format: str, time: float, stream: av.AudioStream
+) -> av.AudioFrame:
+    assert stream.time_base is not None
+
+    audio_frame = av.AudioFrame.from_ndarray(
+        audio_data, format=format, layout=stream.layout.name
+    )
+    audio_frame.sample_rate = stream.rate
+    audio_frame.time_base = stream.time_base
+    audio_frame.pts = int(time / audio_frame.time_base)
+    audio_frame.dts = audio_frame.pts
+
+    return audio_frame
 
 
 class AudioPlugin(neon_player.Plugin):
@@ -47,11 +66,11 @@ class AudioPlugin(neon_player.Plugin):
         self.get_timeline().toolbar_layout.removeWidget(self.volume_button)
         self.get_timeline().remove_timeline_plot("Audio")
 
-    def on_media_status_changed(self, status: QMediaPlayer.MediaStatus):
+    def on_media_status_changed(self, status: QMediaPlayer.MediaStatus) -> None:
         if status == QMediaPlayer.MediaStatus.LoadedMedia:
             self.sync_position()
 
-    def sync_position(self):
+    def sync_position(self) -> None:
         if not self.recording_has_audio:
             return
 
@@ -94,7 +113,7 @@ class AudioPlugin(neon_player.Plugin):
         else:
             self.player.stop()
 
-    def sync_and_start_playback(self):
+    def sync_and_start_playback(self) -> None:
         self.sync_position()
         if self.has_audio_at_ts and self.app.is_playing and self.app.playback_speed > 0:
             self.player.play()
@@ -115,7 +134,7 @@ class AudioPlugin(neon_player.Plugin):
         else:
             self.load_audio()
 
-    def load_audio(self):
+    def load_audio(self) -> None:
         if not self.cache_file.exists():
             return
 
@@ -133,7 +152,7 @@ class AudioPlugin(neon_player.Plugin):
         timeline.add_timeline_line("Audio", data)
         self.recording_has_audio = True
 
-    def extract_audio(self):
+    def extract_audio(self) -> T.Generator[ProgressUpdate, None, None]:
         self.cache_file.parent.mkdir(parents=True, exist_ok=True)
 
         container = av.open(str(self.cache_file), "w")
@@ -143,50 +162,37 @@ class AudioPlugin(neon_player.Plugin):
             yield ProgressUpdate(1.0)
             return
 
+        # Setting these parameters once and reusing them below to ensure
+        # consistency across frames that come from different mp4 files
         stream.layout = self.recording.audio[0].av_frame.layout
+        stream.time_base = fractions.Fraction(1, stream.rate)
 
+        start_time = self.recording.audio.time[0]
         next_expected_frame_time = None
         frame_duration = 0
-
         for frame in self.recording.audio:
-            rel_time = (frame.time - self.recording.audio.time[0]) / 1e9
             raw_audio = frame.to_ndarray()
+            format = frame.av_frame.format
+
             if next_expected_frame_time is not None:
                 # fill in gaps
                 gap = (frame.time - next_expected_frame_time) / 1e9
                 if gap > frame_duration:
-                    samples_to_gen = int(gap * frame.av_frame.sample_rate)
-                    silence = np.zeros([raw_audio.shape[0], samples_to_gen]).astype(
-                        np.float32
-                    )
+                    samples_to_gen = int(gap * stream.sample_rate)
+                    silence = np.zeros([raw_audio.shape[0], samples_to_gen])
 
-                    silence_frame = av.AudioFrame.from_ndarray(
-                        silence,
-                        format=frame.av_frame.format,
-                        layout=frame.av_frame.layout,
+                    silence_rel_time = (next_expected_frame_time - start_time) / 1e9
+                    silence_frame = _prepare_audio_frame(
+                        silence.astype(np.float32), format, silence_rel_time, stream
                     )
-                    silence_frame.sample_rate = frame.av_frame.sample_rate
-                    silence_frame.time_base = frame.av_frame.time_base
-                    silence_rel_time = (
-                        next_expected_frame_time - self.recording.audio.time[0]
-                    ) / 1e9
-                    silence_frame.pts = silence_rel_time / silence_frame.time_base
-                    silence_frame.dts = silence_frame.pts
                     for packet in stream.encode(silence_frame):
                         container.mux(packet)
 
-            frame_duration = frame.to_ndarray().shape[1] / frame.av_frame.sample_rate
+            frame_duration = raw_audio.shape[1] / stream.sample_rate
             next_expected_frame_time = frame.time + frame_duration * 1e9
 
-            frame_copy = av.AudioFrame.from_ndarray(
-                raw_audio,
-                format=frame.av_frame.format,
-                layout=frame.av_frame.layout,
-            )
-            frame_copy.sample_rate = frame.av_frame.sample_rate
-            frame_copy.time_base = frame.av_frame.time_base
-            frame_copy.pts = rel_time / frame_copy.time_base
-            frame_copy.dts = frame_copy.pts
+            rel_time = (frame.time - start_time) / 1e9
+            frame_copy = _prepare_audio_frame(raw_audio, format, rel_time, stream)
             for packet in stream.encode(frame_copy):
                 container.mux(packet)
 
@@ -200,15 +206,15 @@ class AudioPlugin(neon_player.Plugin):
 
 
 class VolumeButton(QPushButton):
-    def __init__(self, audio_output):
+    def __init__(self, audio_output: QAudioOutput) -> None:
         super().__init__()
         self.audio_output = audio_output
 
         self.setIcon(QPixmap(neon_player.asset_path("volume-3.svg")))
-        self.popup = None
+        self.popup: QFrame | None = None
         self.clicked.connect(self.toggle_popup)
 
-    def toggle_popup(self):
+    def toggle_popup(self) -> None:
         if self.popup and self.popup.isVisible():
             self.popup.close()
             return
@@ -218,14 +224,15 @@ class VolumeButton(QPushButton):
         layout = QVBoxLayout(self.popup)
         layout.setContentsMargins(11, 5, 11, 5)
 
-        slider = QSlider(Qt.Vertical)
+        slider = QSlider(Qt.Orientation.Vertical)
         slider.sliderMoved.connect(self.on_slider_moved)
         slider.setValue(int(self.audio_output.volume() * 100))
         slider.setMinimumHeight(140)
         slider.setSizePolicy(QSizePolicy.Policy.Minimum, QSizePolicy.Policy.Minimum)
-        layout.addWidget(slider, alignment=Qt.AlignCenter)
+        layout.addWidget(slider, alignment=Qt.AlignmentFlag.AlignCenter)
 
-        def set_position():
+        def set_position() -> None:
+            assert self.popup is not None
             pos = self.mapToGlobal(self.rect().topLeft())
             pos.setY(pos.y() - self.popup.height())
             self.popup.move(pos)
@@ -233,6 +240,6 @@ class VolumeButton(QPushButton):
         self.popup.show()
         QTimer.singleShot(1, set_position)
 
-    def on_slider_moved(self, value):
+    def on_slider_moved(self, value: int) -> None:
         self.audio_output.setVolume(value / 100)
         self.setIcon(QPixmap(neon_player.asset_path(f"volume-{value//25}.svg")))

--- a/tests/test_plugins/test_audio.py
+++ b/tests/test_plugins/test_audio.py
@@ -10,7 +10,7 @@ MockAudioLayout = namedtuple("MockAudioLayout", ["name"])
 
 
 def test_prepare_audio_frame__correct_data():
-    data = np.zeros((1, 1024), dtype=np.int16)
+    data = np.random.default_rng().integers(-32768, 32767, size=(1, 1024), dtype=np.int16)
     mock_layout = MockAudioLayout(name="mono")
     mock_stream = MockAudioStream(
         layout=mock_layout, rate=44100, time_base=fractions.Fraction(1, 44100)
@@ -23,7 +23,7 @@ def test_prepare_audio_frame__correct_data():
 
 
 def test_prepare_audio_frame__uses_stream_params():
-    data = np.zeros((1, 1024), dtype=np.int16)
+    data = np.random.default_rng().integers(-32768, 32767, size=(1, 1024), dtype=np.int16)
     mock_layout = MockAudioLayout(name="mono")
     mock_stream = MockAudioStream(
         layout=mock_layout, rate=44100, time_base=fractions.Fraction(1, 44100)

--- a/tests/test_plugins/test_audio.py
+++ b/tests/test_plugins/test_audio.py
@@ -1,0 +1,35 @@
+import fractions
+import numpy as np
+
+from collections import namedtuple
+from pupil_labs.neon_player.plugins.audio import _prepare_audio_frame
+
+
+MockAudioStream = namedtuple("MockAudioStream", ["layout", "rate", "time_base"])
+MockAudioLayout = namedtuple("MockAudioLayout", ["name"])
+
+
+def test_prepare_audio_frame__correct_data():
+    data = np.zeros((1, 1024), dtype=np.int16)
+    mock_layout = MockAudioLayout(name="mono")
+    mock_stream = MockAudioStream(
+        layout=mock_layout, rate=44100, time_base=fractions.Fraction(1, 44100)
+    )
+    frame = _prepare_audio_frame(data, format="s16", time=0.5, stream=mock_stream)
+
+    assert np.allclose(frame.to_ndarray(), data)
+    assert frame.pts == 22050
+    assert frame.dts == 22050
+
+
+def test_prepare_audio_frame__uses_stream_params():
+    data = np.zeros((1, 1024), dtype=np.int16)
+    mock_layout = MockAudioLayout(name="mono")
+    mock_stream = MockAudioStream(
+        layout=mock_layout, rate=44100, time_base=fractions.Fraction(1, 44100)
+    )
+    frame = _prepare_audio_frame(data, format="s16", time=0.5, stream=mock_stream)
+
+    assert frame.layout.name == mock_stream.layout.name
+    assert frame.sample_rate == mock_stream.rate
+    assert frame.time_base == mock_stream.time_base

--- a/uv.lock
+++ b/uv.lock
@@ -5,9 +5,12 @@ resolution-markers = [
     "python_full_version >= '3.14' and sys_platform == 'win32'",
     "python_full_version >= '3.14' and sys_platform == 'emscripten'",
     "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'win32'",
-    "python_full_version < '3.14' and sys_platform == 'emscripten'",
-    "python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
 ]
 
 [[package]]
@@ -1012,6 +1015,43 @@ wheels = [
 ]
 
 [[package]]
+name = "numpy-typing-compat"
+version = "20251206.2.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/77/83/dd90774d6685664cbe5525645a50c4e6c7454207aee552918790e879137f/numpy_typing_compat-20251206.2.3.tar.gz", hash = "sha256:18e00e0f4f2040fe98574890248848c7c6831a975562794da186cf4f3c90b935", size = 5009, upload-time = "2025-12-06T20:02:04.177Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/48/6f/dde8e2a79a3b6cbc31bc1037c1a1dbc07c90d52d946851bd7cba67e730a8/numpy_typing_compat-20251206.2.3-py3-none-any.whl", hash = "sha256:bfa2e4c4945413e84552cbd34a6d368c88a06a54a896e77ced760521b08f0f61", size = 6300, upload-time = "2025-12-06T20:01:56.664Z" },
+]
+
+[[package]]
+name = "numpy-typing-compat"
+version = "20260602.2.3"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/cc/1b/c3906ddf31b083d73ac93ca2fdee5f4db6cb3bddd18ceff4ebd49b720726/numpy_typing_compat-20260602.2.3.tar.gz", hash = "sha256:f06c8aaca9fa6a9047a7aba5474a7e33870b954544ff276de000dad68c640fbf", size = 4597, upload-time = "2026-06-02T15:52:37.686Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/15/b2/99c1f33f85198d504edb0e1ff5342c3af6ecf2cd5b71d4529fdd05f837c9/numpy_typing_compat-20260602.2.3-py3-none-any.whl", hash = "sha256:2fa13965f068e2ecc7dec9a1883e1381ea506f1d19d435399dde88fc68f0da01", size = 5882, upload-time = "2026-06-02T15:52:32.108Z" },
+]
+
+[[package]]
 name = "numpyencoder"
 version = "0.3.2"
 source = { registry = "https://pypi.org/simple" }
@@ -1040,6 +1080,55 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/55/b3b49a1b97aabcfbbd6c7326df9cb0b6fa0c0aefa8e89d500939e04aa229/opencv_python-4.13.0.92-cp37-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:620d602b8f7d8b8dab5f4b99c6eb353e78d3fb8b0f53db1bd258bb1aa001c1d5", size = 72927042, upload-time = "2026-02-05T06:59:23.389Z" },
     { url = "https://files.pythonhosted.org/packages/fb/17/de5458312bcb07ddf434d7bfcb24bb52c59635ad58c6e7c751b48949b009/opencv_python-4.13.0.92-cp37-abi3-win32.whl", hash = "sha256:372fe164a3148ac1ca51e5f3ad0541a4a276452273f503441d718fab9c5e5f59", size = 30932638, upload-time = "2026-02-05T07:02:14.98Z" },
     { url = "https://files.pythonhosted.org/packages/e9/a5/1be1516390333ff9be3a9cb648c9f33df79d5096e5884b5df71a588af463/opencv_python-4.13.0.92-cp37-abi3-win_amd64.whl", hash = "sha256:423d934c9fafb91aad38edf26efb46da91ffbc05f3f59c4b0c72e699720706f5", size = 40212062, upload-time = "2026-02-05T07:02:12.724Z" },
+]
+
+[[package]]
+name = "optype"
+version = "0.17.1"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9b/86/e6f1f6f3487492dfcf3b7a2d4e2534d27af6ac05b364b276706906c34865/optype-0.17.1.tar.gz", hash = "sha256:07bfa32b795dea28fba8605a6288d36370d072f25183fb9c29b5a90f4b6f5638", size = 53572, upload-time = "2026-05-17T22:13:28.725Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2f/d4/c6a2b043e33f0dd012486dcebe0593585588d400175d22aad42049c88321/optype-0.17.1-py3-none-any.whl", hash = "sha256:82f2508ca31cb21e53a41648482d890fe1f5c6cb153720551af41161555adaf1", size = 65954, upload-time = "2026-05-17T22:13:27.549Z" },
+]
+
+[package.optional-dependencies]
+numpy = [
+    { name = "numpy", marker = "python_full_version < '3.12'" },
+    { name = "numpy-typing-compat", version = "20251206.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+]
+
+[[package]]
+name = "optype"
+version = "0.18.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "typing-extensions", marker = "python_full_version == '3.12.*'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/99/51/51dc9b1009e020f44703933d4d1ee3429c647c026ce7806b37ee2b257998/optype-0.18.0.tar.gz", hash = "sha256:ea10dee61b15ca299ed0d97025d362585c4dfc5481159bb999a1d0d414bbcb04", size = 59967, upload-time = "2026-06-07T22:13:17.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5b/91/2b064a117cb2593bc3eb04ee994134ca2a6bf2162c92961769947e3258cc/optype-0.18.0-py3-none-any.whl", hash = "sha256:91822ed8516e7a4f225ba53d30f291776c35f31553fb952d7cda98286679c5a6", size = 73410, upload-time = "2026-06-07T22:13:16.324Z" },
+]
+
+[package.optional-dependencies]
+numpy = [
+    { name = "numpy", marker = "python_full_version >= '3.12'" },
+    { name = "numpy-typing-compat", version = "20260602.2.3", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
 ]
 
 [[package]]
@@ -1324,6 +1413,8 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-qt" },
+    { name = "scipy-stubs", version = "1.17.1.5", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version < '3.12'" },
+    { name = "scipy-stubs", version = "1.18.0.0", source = { registry = "https://pypi.org/simple" }, marker = "python_full_version >= '3.12'" },
     { name = "tox-uv" },
 ]
 
@@ -1371,6 +1462,7 @@ dev = [
     { name = "pytest", specifier = ">=8.2" },
     { name = "pytest-cov", specifier = ">=4.0.0" },
     { name = "pytest-qt", specifier = ">=4.5.0" },
+    { name = "scipy-stubs", specifier = ">=1.17.1.5" },
     { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0" },
     { name = "tox-uv", specifier = ">=1.11.3" },
 ]
@@ -4536,6 +4628,43 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/52/52/e57eceff0e342a1f50e274264ed47497b59e6a4e3118808ee58ddda7b74a/scipy-1.17.1-cp314-cp314t-musllinux_1_2_x86_64.whl", hash = "sha256:a77cbd07b940d326d39a1d1b37817e2ee4d79cb30e7338f3d0cddffae70fcaa2", size = 37682317, upload-time = "2026-02-23T00:22:18.513Z" },
     { url = "https://files.pythonhosted.org/packages/11/2f/b29eafe4a3fbc3d6de9662b36e028d5f039e72d345e05c250e121a230dd4/scipy-1.17.1-cp314-cp314t-win_amd64.whl", hash = "sha256:eb092099205ef62cd1782b006658db09e2fed75bffcae7cc0d44052d8aa0f484", size = 37345327, upload-time = "2026-02-23T00:22:24.442Z" },
     { url = "https://files.pythonhosted.org/packages/07/39/338d9219c4e87f3e708f18857ecd24d22a0c3094752393319553096b98af/scipy-1.17.1-cp314-cp314t-win_arm64.whl", hash = "sha256:200e1050faffacc162be6a486a984a0497866ec54149a01270adc8a59b7c7d21", size = 25489165, upload-time = "2026-02-23T00:22:29.563Z" },
+]
+
+[[package]]
+name = "scipy-stubs"
+version = "1.17.1.5"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version < '3.12' and sys_platform == 'win32'",
+    "python_full_version < '3.12' and sys_platform == 'emscripten'",
+    "python_full_version < '3.12' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "optype", version = "0.17.1", source = { registry = "https://pypi.org/simple" }, extra = ["numpy"], marker = "python_full_version < '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/02/30/7a2e621918d1317ab972f797161131f2635648ad5d92baf0695dd009e4f9/scipy_stubs-1.17.1.5.tar.gz", hash = "sha256:284b1dd1dd46107a614971d170030d310cd88b2ac6b483f85285ee0ff87720bd", size = 399933, upload-time = "2026-05-25T21:34:33.6Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/26/d4bc2ba3427a623f79a6c10c8f427c7a55b56eb8b3eddc369319d97f741b/scipy_stubs-1.17.1.5-py3-none-any.whl", hash = "sha256:58ebf054a86c000c72e8982e121c4ead0d3d9ba7a6c38aa5fa71b07f96a427fd", size = 607388, upload-time = "2026-05-25T21:34:32.073Z" },
+]
+
+[[package]]
+name = "scipy-stubs"
+version = "1.18.0.0"
+source = { registry = "https://pypi.org/simple" }
+resolution-markers = [
+    "python_full_version >= '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'win32'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform == 'emscripten'",
+    "python_full_version >= '3.12' and python_full_version < '3.14' and sys_platform != 'emscripten' and sys_platform != 'win32'",
+]
+dependencies = [
+    { name = "optype", version = "0.18.0", source = { registry = "https://pypi.org/simple" }, extra = ["numpy"], marker = "python_full_version >= '3.12'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e5/9b/6cb11393563241c79b74e035c1d697329d1dce1635565e40b0085d56a2fe/scipy_stubs-1.18.0.0.tar.gz", hash = "sha256:a1fc917da66e4d338998839170e218754a669f6455c24243890a1e572bde98f6", size = 402538, upload-time = "2026-06-19T10:56:39.57Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e9/b4/82d4de656500722dea533151b88f926672341b46289cc31eb2e2c1c7c1d7/scipy_stubs-1.18.0.0-py3-none-any.whl", hash = "sha256:872ec1066a75feb5c5d8451231e8f7826d08d53fb806c526abd5f97bb1ba29fb", size = 608175, upload-time = "2026-06-19T10:56:37.905Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
In some multi-part recordings, stream parameters (e.g., `time_base`) differ between recording parts and therefore between frames. This inconsistency leads to an error during encoding, and this PR fixes it by using fixed parameters across all frames.