### PR TITLE
fix(deps): canonicalize package names to fix snake_case dependency detection

### DIFF
--- a/src/pupil_labs/neon_player/plugin_management/dependencies.py
+++ b/src/pupil_labs/neon_player/plugin_management/dependencies.py
@@ -1,6 +1,5 @@
 import importlib.metadata
 import logging
-import re
 import subprocess
 import sys
 import typing as T

--- a/src/pupil_labs/neon_player/plugin_management/dependencies.py
+++ b/src/pupil_labs/neon_player/plugin_management/dependencies.py
@@ -5,6 +5,7 @@ import sys
 import typing as T
 
 from packaging.requirements import InvalidRequirement, Requirement
+from packaging.utils import canonicalize_name
 from pathlib import Path
 
 from pupil_labs import neon_player
@@ -24,7 +25,7 @@ def get_installed_packages() -> dict[str, str]:
     shared site-packages."""
     try:
         return {
-            dist.metadata["name"]: dist.metadata["version"]
+            canonicalize_name(dist.metadata["name"]): dist.metadata["version"]
             for dist in importlib.metadata.distributions()
         }
     except Exception as e:
@@ -37,10 +38,11 @@ def get_installed_packages() -> dict[str, str]:
 def is_dependency_installed(dependency: str, installed_packages: dict[str, str]) -> bool:
     """Check if a dependency is already installed in the shared site-packages."""
     req = Requirement(dependency)
-    if req.name not in installed_packages:
+    req_name = canonicalize_name(req.name)
+    if req_name not in installed_packages:
         return False
 
-    installed_version = installed_packages[req.name]
+    installed_version = installed_packages[req_name]
     return req.specifier.contains(installed_version)
 
 

--- a/src/pupil_labs/neon_player/plugin_management/dependencies.py
+++ b/src/pupil_labs/neon_player/plugin_management/dependencies.py
@@ -1,11 +1,12 @@
 import importlib.metadata
 import logging
+import re
 import subprocess
 import sys
 import typing as T
 
 from packaging.requirements import InvalidRequirement, Requirement
-from packaging.utils import canonicalize_name
+from packaging.utils import canonicalize_name, NormalizedName
 from pathlib import Path
 
 from pupil_labs import neon_player
@@ -20,9 +21,13 @@ SITE_PACKAGES_DIR = PLUGINS_PACKAGES_DIR / "site-packages"
 SITE_PACKAGES_DIR.mkdir(parents=True, exist_ok=True)
 
 
-def get_installed_packages() -> dict[str, str]:
-    """Get a dictionary of installed package names and their versions in the
-    shared site-packages."""
+def get_installed_packages() -> dict[NormalizedName, str]:
+    """
+    Get a dictionary of installed package names and their versions in the shared site-packages.
+
+    Dependency names are normalized according to:
+    https://packaging.python.org/en/latest/specifications/name-normalization/#name-normalization.
+    """
     try:
         return {
             canonicalize_name(dist.metadata["name"]): dist.metadata["version"]
@@ -35,7 +40,7 @@ def get_installed_packages() -> dict[str, str]:
         return {}
 
 
-def is_dependency_installed(dependency: str, installed_packages: dict[str, str]) -> bool:
+def is_dependency_installed(dependency: str, installed_packages: dict[NormalizedName, str]) -> bool:
     """Check if a dependency is already installed in the shared site-packages."""
     req = Requirement(dependency)
     req_name = canonicalize_name(req.name)

--- a/tests/test_plugin_management/test_dependencies.py
+++ b/tests/test_plugin_management/test_dependencies.py
@@ -24,6 +24,7 @@ import os
 
 
 def test_is_dependency_installed__installed():
+    # Canonical form stored in the dict (as get_installed_packages() now does)
     installed_packages = {"numpy": "2.0"}
     assert is_dependency_installed("numpy", installed_packages)
 
@@ -41,6 +42,39 @@ def test_is_dependency_installed__installed_version_satisfies_specifier():
 def test_is_dependency_installed__installed_version_does_not_satisfy_specifier():
     installed_packages = {"numpy": "2.0"}
     assert not is_dependency_installed("numpy<2.0", installed_packages)
+
+
+# --- Regression tests: snake_case / hyphen name normalization ---
+
+
+def test_is_dependency_installed__snake_dep_hyphen_installed():
+    """Dependency declared with underscore, metadata stored with hyphen."""
+    installed_packages = {"some-package": "1.0"}
+    assert is_dependency_installed("some_package", installed_packages)
+
+
+def test_is_dependency_installed__hyphen_dep_snake_installed():
+    """Dependency declared with hyphen, metadata stored with underscore."""
+    installed_packages = {"some_package": "1.0"}
+    assert is_dependency_installed("some-package", installed_packages)
+
+
+def test_is_dependency_installed__both_canonical():
+    """Both sides already canonical (all-lowercase, hyphens); no regression."""
+    installed_packages = {"some-package": "1.0"}
+    assert is_dependency_installed("some-package", installed_packages)
+
+
+def test_is_dependency_installed__snake_dep_snake_installed():
+    """Both sides use underscores; should still match after canonicalization."""
+    installed_packages = {"some_package": "1.0"}
+    assert is_dependency_installed("some_package", installed_packages)
+
+
+def test_is_dependency_installed__mixed_case_dep():
+    """Dependency name with mixed case; canonical form is lowercase."""
+    installed_packages = {"some-package": "1.0"}
+    assert is_dependency_installed("Some_Package", installed_packages)
 
 
 def test_check_dependencies_for_plugin_script__all_deps_installed():
@@ -61,3 +95,36 @@ def test_check_dependencies_for_plugin_script__missing_dep():
         result = _check_dependencies_for_plugin_script(script, "test_plugin")
         assert len(result) == 1
         assert "some-missing-lib" in result[0]
+
+
+# --- Regression: snake_case deps in full plugin script flow ---
+
+
+def test_check_dependencies_for_plugin_script__snake_dep_detected_as_installed():
+    """Regression: a dep declared with underscore must not trigger re-install
+    when the package is already present under its hyphenated canonical name."""
+    script = _plugin_script(["some_package>=1.0"])
+    with patch(
+        "pupil_labs.neon_player.plugin_management.dependencies.get_installed_packages",
+        return_value={"some-package": "1.0"},  # canonical form, as stored by pip/uv
+    ):
+        result = _check_dependencies_for_plugin_script(script, "test_plugin")
+        assert result == [], (
+            "snake_case dep should be recognized as installed when the "
+            "package is present under its canonical (hyphenated) name"
+        )
+
+
+def test_check_dependencies_for_plugin_script__hyphen_dep_detected_as_installed():
+    """Regression: a dep declared with hyphen must not trigger re-install
+    when the package is already present under its underscored metadata name."""
+    script = _plugin_script(["some-package>=1.0"])
+    with patch(
+        "pupil_labs.neon_player.plugin_management.dependencies.get_installed_packages",
+        return_value={"some_package": "1.0"},
+    ):
+        result = _check_dependencies_for_plugin_script(script, "test_plugin")
+        assert result == [], (
+            "hyphenated dep should be recognized as installed when the "
+            "package metadata uses underscores"
+        )

--- a/tests/test_plugin_management/test_dependencies.py
+++ b/tests/test_plugin_management/test_dependencies.py
@@ -30,7 +30,6 @@ def test_get_installed_packages__names_are_normalized(mock_distributions):
 
 
 def test_is_dependency_installed__installed():
-    # Canonical form stored in the dict (as get_installed_packages() now does)
     installed_packages = {"numpy": "2.0"}
     assert is_dependency_installed("numpy", installed_packages)
 
@@ -57,7 +56,6 @@ def test_is_dependency_installed__installed_version_does_not_satisfy_specifier()
     "Some_Package",
 ])
 def test_is_dependency_installed__name_is_normalized(dependency_name):
-    """Dependency declared with underscore, metadata stored with hyphen."""
     installed_packages = {"some-package": "1.0"}
     assert is_dependency_installed(dependency_name, installed_packages)
 

--- a/tests/test_plugin_management/test_dependencies.py
+++ b/tests/test_plugin_management/test_dependencies.py
@@ -1,12 +1,12 @@
-from pathlib import Path
-from unittest.mock import patch
-
 import pytest
+
+from packaging.utils import canonicalize_name
+from unittest.mock import patch
 
 from pupil_labs.neon_player.plugin_management.dependencies import (
     _check_dependencies_for_plugin_script,
-    is_dependency_installed,
     get_installed_packages,
+    is_dependency_installed
 )
 
 
@@ -21,6 +21,12 @@ def _plugin_script(deps: list[str]) -> str:
 # ///
 import os
 """
+
+
+@patch("importlib.metadata.distributions", return_value=["huggingface_hub", "tf_keras"])
+def test_get_installed_packages__names_are_normalized(mock_distributions):
+    for package in get_installed_packages():
+        assert package == canonicalize_name(package)
 
 
 def test_is_dependency_installed__installed():
@@ -44,37 +50,16 @@ def test_is_dependency_installed__installed_version_does_not_satisfy_specifier()
     assert not is_dependency_installed("numpy<2.0", installed_packages)
 
 
-# --- Regression tests: snake_case / hyphen name normalization ---
-
-
-def test_is_dependency_installed__snake_dep_hyphen_installed():
+@pytest.mark.parametrize("dependency_name", [
+    "some-package",
+    "some_package",
+    "some.package",
+    "Some_Package",
+])
+def test_is_dependency_installed__name_is_normalized(dependency_name):
     """Dependency declared with underscore, metadata stored with hyphen."""
     installed_packages = {"some-package": "1.0"}
-    assert is_dependency_installed("some_package", installed_packages)
-
-
-def test_is_dependency_installed__hyphen_dep_snake_installed():
-    """Dependency declared with hyphen, metadata stored with underscore."""
-    installed_packages = {"some_package": "1.0"}
-    assert is_dependency_installed("some-package", installed_packages)
-
-
-def test_is_dependency_installed__both_canonical():
-    """Both sides already canonical (all-lowercase, hyphens); no regression."""
-    installed_packages = {"some-package": "1.0"}
-    assert is_dependency_installed("some-package", installed_packages)
-
-
-def test_is_dependency_installed__snake_dep_snake_installed():
-    """Both sides use underscores; should still match after canonicalization."""
-    installed_packages = {"some_package": "1.0"}
-    assert is_dependency_installed("some_package", installed_packages)
-
-
-def test_is_dependency_installed__mixed_case_dep():
-    """Dependency name with mixed case; canonical form is lowercase."""
-    installed_packages = {"some-package": "1.0"}
-    assert is_dependency_installed("Some_Package", installed_packages)
+    assert is_dependency_installed(dependency_name, installed_packages)
 
 
 def test_check_dependencies_for_plugin_script__all_deps_installed():
@@ -97,34 +82,14 @@ def test_check_dependencies_for_plugin_script__missing_dep():
         assert "some-missing-lib" in result[0]
 
 
-# --- Regression: snake_case deps in full plugin script flow ---
-
-
 def test_check_dependencies_for_plugin_script__snake_dep_detected_as_installed():
-    """Regression: a dep declared with underscore must not trigger re-install
-    when the package is already present under its hyphenated canonical name."""
     script = _plugin_script(["some_package>=1.0"])
     with patch(
         "pupil_labs.neon_player.plugin_management.dependencies.get_installed_packages",
-        return_value={"some-package": "1.0"},  # canonical form, as stored by pip/uv
+        return_value={"some-package": "1.0"},
     ):
         result = _check_dependencies_for_plugin_script(script, "test_plugin")
         assert result == [], (
             "snake_case dep should be recognized as installed when the "
             "package is present under its canonical (hyphenated) name"
-        )
-
-
-def test_check_dependencies_for_plugin_script__hyphen_dep_detected_as_installed():
-    """Regression: a dep declared with hyphen must not trigger re-install
-    when the package is already present under its underscored metadata name."""
-    script = _plugin_script(["some-package>=1.0"])
-    with patch(
-        "pupil_labs.neon_player.plugin_management.dependencies.get_installed_packages",
-        return_value={"some_package": "1.0"},
-    ):
-        result = _check_dependencies_for_plugin_script(script, "test_plugin")
-        assert result == [], (
-            "hyphenated dep should be recognized as installed when the "
-            "package metadata uses underscores"
         )


### PR DESCRIPTION
## Problem

After the refactor in commit `09f2989` (*chore: refactor, check versions of installed packages*), plugin dependency detection broke for packages whose names contain underscores (snake_case).

### Root Cause

The `is_dependency_installed` function compared the requested dependency name directly against the name reported by `importlib.metadata`:

```python
req = Requirement(dependency)
if req.name not in installed_packages:  # ← raw string comparison
    return False
```

According to [PEP 503](https://peps.python.org/pep-0503/), package names must be treated as equivalent regardless of whether they use underscores (`_`), hyphens (`-`), or periods (`.`). For example, `some_package`, `some-package`, and `some.package` are all the same package.

When a plugin declared a dependency like `some_package` but pip/uv stored the metadata under `some-package` (or vice versa), the lookup failed — causing the package to appear as not installed and triggering a redundant (or erroneous) re-installation attempt on every launch.

## Solution

Use `canonicalize_name` from `packaging.utils` to normalise both sides of the comparison before looking up:

- **`get_installed_packages()`** — keys in the returned dict are now canonicalized.
- **`is_dependency_installed()`** — the requirement name is canonicalized before the dict lookup.

```python
from packaging.utils import canonicalize_name

# in get_installed_packages():
canonicalize_name(dist.metadata["name"]): dist.metadata["version"]

# in is_dependency_installed():
req_name = canonicalize_name(req.name)
if req_name not in installed_packages:
    ...
```

## Tests

Regression tests have been added to `tests/test_plugin_management/test_dependencies.py` covering:

| Scenario | Level |
|---|---|
| Dep with `_`, metadata with `-` | unit |
| Dep with `-`, metadata with `_` | unit |
| Both canonical (no regression) | unit |
| Both underscored | unit |
| Mixed-case dep name | unit |
| Full script flow: snake dep → hyphen metadata → not re-installed | integration |
| Full script flow: hyphen dep → snake metadata → not re-installed | integration |