### PR TITLE
feat(events): support multiple recordings in the events plugin

### DIFF
--- a/src/pupil_labs/neon_player/job_manager.py
+++ b/src/pupil_labs/neon_player/job_manager.py
@@ -69,12 +69,12 @@ class BaseBackgroundJob(QObject):
     finished = Signal()
     canceled = Signal()
 
-    def __init__(self, name: str, job_id: int, action_name: str, warn_on_cancel):
+    def __init__(self, name: str, job_id: int, action_name: str, confirm_cancel: str):
         super().__init__()
         self.name = name
         self.job_id = job_id
         self.action_name = action_name
-        self.warn_on_cancel = warn_on_cancel
+        self.confirm_cancel = confirm_cancel
         self.progress = -1
 
     def cancel(self):
@@ -91,9 +91,9 @@ class BackgroundJob(BaseBackgroundJob):
         *args: T.Any,
         recording_settings_path: Path | None = None,
         workspace_settings_path: Path | None = None,
-        warn_on_cancel: str = "",
+        confirm_cancel: str = "",
     ):
-        super().__init__(name, job_id, action_name, warn_on_cancel)
+        super().__init__(name, job_id, action_name, confirm_cancel)
 
         self.socket = None
         self._expected_payload_size = None
@@ -185,9 +185,9 @@ class BatchBackgroundJob(BaseBackgroundJob):
         action_name: str,
         args_generator: T.Callable[[NeonRecording], T.Any] | None = None,
         recordings: list[NeonRecording] | None = None,
-        warn_on_cancel: str = ""
+        confirm_cancel: str = ""
     ):
-        super().__init__(name, job_id, action_name, warn_on_cancel)
+        super().__init__(name, job_id, action_name, confirm_cancel)
 
         app = neon_player.instance()
         if not app.batch_mode_enabled:
@@ -277,7 +277,7 @@ class BatchBackgroundJob(BaseBackgroundJob):
             recording_settings_path=self._tmp_recording_settings_path(current_recording),
             workspace_settings_path=self._tmp_workspace_settings_path(),
             notify_on_completion=False,
-            warn_on_cancel=self.warn_on_cancel
+            confirm_cancel=self.confirm_cancel
         )
         sub_job.canceled.connect(lambda: self._on_sub_job_canceled())
         sub_job.finished.connect(lambda: self._on_sub_job_finished())
@@ -361,7 +361,7 @@ class JobManager(QObject):
         recording_settings_path: Path | None = None,
         workspace_settings_path: Path | None = None,
         notify_on_completion: bool = True,
-        warn_on_cancel: str = ""
+        confirm_cancel: str = ""
     ) -> BackgroundJob:
         if neon_player.instance().headless:
             logging.warning("Not starting background job in headless mode")
@@ -385,7 +385,7 @@ class JobManager(QObject):
             *args,
             recording_settings_path=recording_settings_path,
             workspace_settings_path=workspace_settings_path,
-            warn_on_cancel=warn_on_cancel
+            confirm_cancel=confirm_cancel
         )
         self._job_counter += 1
 
@@ -407,7 +407,7 @@ class JobManager(QObject):
         action_name: str,
         args_generator: T.Callable[[NeonRecording], T.Any] | None = None,
         recordings: list[NeonRecording] | None = None,
-        warn_on_cancel: str = ""
+        confirm_cancel: str = ""
     ) -> BatchBackgroundJob:
         neon_player.instance().save_settings()
 
@@ -417,7 +417,7 @@ class JobManager(QObject):
             action_name,
             args_generator=args_generator,
             recordings=recordings,
-            warn_on_cancel=warn_on_cancel
+            confirm_cancel=confirm_cancel
         )
         self._job_counter += 1
 

--- a/src/pupil_labs/neon_player/job_manager.py
+++ b/src/pupil_labs/neon_player/job_manager.py
@@ -69,11 +69,12 @@ class BaseBackgroundJob(QObject):
     finished = Signal()
     canceled = Signal()
 
-    def __init__(self, name: str, job_id: int, action_name: str):
+    def __init__(self, name: str, job_id: int, action_name: str, warn_on_cancel):
         super().__init__()
         self.name = name
         self.job_id = job_id
         self.action_name = action_name
+        self.warn_on_cancel = warn_on_cancel
         self.progress = -1
 
     def cancel(self):
@@ -90,8 +91,9 @@ class BackgroundJob(BaseBackgroundJob):
         *args: T.Any,
         recording_settings_path: Path | None = None,
         workspace_settings_path: Path | None = None,
+        warn_on_cancel: str = "",
     ):
-        super().__init__(name, job_id, action_name)
+        super().__init__(name, job_id, action_name, warn_on_cancel)
 
         self.socket = None
         self._expected_payload_size = None
@@ -183,8 +185,9 @@ class BatchBackgroundJob(BaseBackgroundJob):
         action_name: str,
         args_generator: T.Callable[[NeonRecording], T.Any] | None = None,
         recordings: list[NeonRecording] | None = None,
+        warn_on_cancel: str = ""
     ):
-        super().__init__(name, job_id, action_name)
+        super().__init__(name, job_id, action_name, warn_on_cancel)
 
         app = neon_player.instance()
         if not app.batch_mode_enabled:
@@ -274,6 +277,7 @@ class BatchBackgroundJob(BaseBackgroundJob):
             recording_settings_path=self._tmp_recording_settings_path(current_recording),
             workspace_settings_path=self._tmp_workspace_settings_path(),
             notify_on_completion=False,
+            warn_on_cancel=self.warn_on_cancel
         )
         sub_job.canceled.connect(lambda: self._on_sub_job_canceled())
         sub_job.finished.connect(lambda: self._on_sub_job_finished())
@@ -356,7 +360,8 @@ class JobManager(QObject):
         recording: NeonRecording | None = None,
         recording_settings_path: Path | None = None,
         workspace_settings_path: Path | None = None,
-        notify_on_completion: bool = True
+        notify_on_completion: bool = True,
+        warn_on_cancel: str = ""
     ) -> BackgroundJob:
         if neon_player.instance().headless:
             logging.warning("Not starting background job in headless mode")
@@ -380,6 +385,7 @@ class JobManager(QObject):
             *args,
             recording_settings_path=recording_settings_path,
             workspace_settings_path=workspace_settings_path,
+            warn_on_cancel=warn_on_cancel
         )
         self._job_counter += 1
 
@@ -400,7 +406,8 @@ class JobManager(QObject):
         name: str,
         action_name: str,
         args_generator: T.Callable[[NeonRecording], T.Any] | None = None,
-        recordings: list[NeonRecording] | None = None
+        recordings: list[NeonRecording] | None = None,
+        warn_on_cancel: str = ""
     ) -> BatchBackgroundJob:
         neon_player.instance().save_settings()
 
@@ -409,7 +416,8 @@ class JobManager(QObject):
             self._job_counter,
             action_name,
             args_generator=args_generator,
-            recordings=recordings
+            recordings=recordings,
+            warn_on_cancel=warn_on_cancel
         )
         self._job_counter += 1
 

--- a/src/pupil_labs/neon_player/job_manager.py
+++ b/src/pupil_labs/neon_player/job_manager.py
@@ -409,7 +409,7 @@ class JobManager(QObject):
         recordings: list[NeonRecording] | None = None,
         confirm_cancel: str = ""
     ) -> BatchBackgroundJob:
-        neon_player.instance().save_settings()
+        neon_player.instance().save_settings(force=True)
 
         job = BatchBackgroundJob(
             name,

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -124,34 +124,53 @@ class Plugin(PersistentPropertiesMixin, QObject):
         reply = QMessageBox.question(None, title, message)
         return reply == QMessageBox.StandardButton.Yes
 
-    def get_cache_path(self, workspace: bool = False) -> Path:
-        if self.recording is None:
-            return None
-
+    def get_cache_path(
+        self,
+        workspace: bool = False,
+        recording: NeonRecording | None = None
+    ) -> Path | None:
         if workspace and self.workspace.path is not None:
             cache_dir = self.workspace.path / ".neon_player" / "cache"
-        else:
-            cache_dir = self.recording._rec_dir / ".neon_player" / "cache"
+            return cache_dir / self.__class__.__name__
 
-        return cache_dir / self.__class__.__name__
+        if recording is None:
+            recording = self.recording
 
-    def load_cached_json(self, filename: str, workspace: bool = False) -> T.Any:
-        if self.recording is None:
+        if recording is None:
             return None
 
-        cache_file = self.get_cache_path(workspace) / filename
+        cache_dir = recording._rec_dir / ".neon_player" / "cache"
+        return cache_dir / self.__class__.__name__
 
+    def load_cached_json(
+        self,
+        filename: str,
+        workspace: bool = False,
+        recording: NeonRecording | None = None
+    ) -> T.Any:
+        cache_path = self.get_cache_path(workspace=workspace, recording=recording)
+        if cache_path is None:
+            return None
+
+        cache_file = cache_path / filename
         if not cache_file.exists():
             return None
 
         with cache_file.open("r") as f:
             return json.load(f)
 
-    def save_cached_json(self, filename: str, data: T.Any, workspace: bool = False) -> None:
-        if self.recording is None:
+    def save_cached_json(
+        self,
+        filename: str,
+        data: T.Any,
+        workspace: bool = False,
+        recording: NeonRecording | None = None
+    ) -> None:
+        cache_path = self.get_cache_path(workspace=workspace, recording=recording)
+        if cache_path is None:
             return
 
-        cache_file = self.get_cache_path(workspace) / filename
+        cache_file = cache_path / filename
         cache_file.parent.mkdir(parents=True, exist_ok=True)
 
         with cache_file.open("w") as f:

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -124,53 +124,34 @@ class Plugin(PersistentPropertiesMixin, QObject):
         reply = QMessageBox.question(None, title, message)
         return reply == QMessageBox.StandardButton.Yes
 
-    def get_cache_path(
-        self,
-        workspace: bool = False,
-        recording: NeonRecording | None = None
-    ) -> Path | None:
+    def get_cache_path(self, workspace: bool = False) -> Path:
+        if self.recording is None:
+            return None
+
         if workspace and self.workspace.path is not None:
             cache_dir = self.workspace.path / ".neon_player" / "cache"
-            return cache_dir / self.__class__.__name__
+        else:
+            cache_dir = self.recording._rec_dir / ".neon_player" / "cache"
 
-        if recording is None:
-            recording = self.recording
-
-        if recording is None:
-            return None
-
-        cache_dir = recording._rec_dir / ".neon_player" / "cache"
         return cache_dir / self.__class__.__name__
 
-    def load_cached_json(
-        self,
-        filename: str,
-        workspace: bool = False,
-        recording: NeonRecording | None = None
-    ) -> T.Any:
-        cache_path = self.get_cache_path(workspace=workspace, recording=recording)
-        if cache_path is None:
+    def load_cached_json(self, filename: str, workspace: bool = False) -> T.Any:
+        if self.recording is None:
             return None
 
-        cache_file = cache_path / filename
+        cache_file = self.get_cache_path(workspace) / filename
+
         if not cache_file.exists():
             return None
 
         with cache_file.open("r") as f:
             return json.load(f)
 
-    def save_cached_json(
-        self,
-        filename: str,
-        data: T.Any,
-        workspace: bool = False,
-        recording: NeonRecording | None = None
-    ) -> None:
-        cache_path = self.get_cache_path(workspace=workspace, recording=recording)
-        if cache_path is None:
+    def save_cached_json(self, filename: str, data: T.Any, workspace: bool = False) -> None:
+        if self.recording is None:
             return
 
-        cache_file = cache_path / filename
+        cache_file = self.get_cache_path(workspace) / filename
         cache_file.parent.mkdir(parents=True, exist_ok=True)
 
         with cache_file.open("w") as f:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -180,6 +180,98 @@ class EventTypeListWidget(ValueListWidget):
         item_widget.deleteLater()
 
 
+class WorkspaceEventIndex():
+    """
+    Maintains an index of all events and the number of their occurrences
+    across all recordings in the workspace to support renaming and deletion.
+    """
+    def __init__(self) -> None:
+        # {event_name: {recording_name: event_count}}
+        self.events: dict[str, dict[str, int]] = {}
+
+        # IDs of recording that the index is based on
+        self.recording_ids: set[str] = set()
+
+    def load(self, data: dict[str, T.Any]) -> None:
+        if data is None:
+            return
+
+        self.events = data.get("events", {})
+        self.recording_ids = set(data.get("recording_ids", []))
+
+    def to_dict(self) -> dict[str, T.Any]:
+        data = {
+            "events": self.events,
+            "recording_ids": list(self.recording_ids)
+        }
+        return data
+
+    def update(self, recording_id: str, recording_events: dict[str, list[int]]) -> None:
+        """
+        Batch index update that goes through all events in the index and all
+        recording events.
+        """
+        # First, check if existing index entries for this recording are up-to-date
+        for event_name, recording_counts in self.events.items():
+            event_in_recording = event_name in recording_events
+            recording_in_index = recording_id in recording_counts
+
+            if recording_in_index and not event_in_recording:
+                del recording_counts[recording_id]
+
+            if event_in_recording:
+                timestamps = recording_events[event_name]
+                self.events[event_name][recording_id] = len(timestamps)
+
+        # Process other events from the recording that are not yet in the index
+        for event_name, timestamps in recording_events.items():
+            if event_name in IMMUTABLE_EVENTS:
+                continue
+
+            if event_name in self.events:
+                continue
+
+            self.events[event_name] = {}
+            self.events[event_name][recording_id] = len(timestamps)
+
+        # Mark recording as processed in the index
+        if recording_id not in self.recording_ids:
+            self.recording_ids.add(recording_id)
+
+    def add_event(self, recording_id: str, event_name: str) -> None:
+        if event_name not in self.events:
+            self.events[event_name] = {}
+
+        if recording_id not in self.events[event_name]:
+            self.events[event_name][recording_id] = 0
+
+    def delete_event(self, recording_id: str, event_name: str) -> None:
+        if event_name not in self.events or recording_id not in self.events[event_name]:
+            return
+
+        self.events[event_name][recording_id] -= 1
+
+        if self.events[event_name][recording_id] <= 0:
+            del self.events[event_name][recording_id]
+        if not self.events[event_name]:
+            del self.events[event_name]
+
+    def rename_event(self, recording_id: str, old_name: str, new_name: str) -> None:
+        if old_name not in self.events:
+            return
+
+        if new_name not in self.events:
+            self.events[new_name] = {}
+
+        self.events[new_name][recording_id] = self.events[old_name].pop(recording_id)
+        if not self.events[old_name]:
+            del self.events[old_name]
+
+    def delete_event_type(self, event_name: str) -> None:
+        if event_name in self.events:
+            del self.events[event_name]
+
+
 def _load_events_from_recording(recording: NeonRecording):
     events: dict[str, list[int]] = {}
 
@@ -204,13 +296,6 @@ def _load_events_from_dataframe(events_df: pd.DataFrame) -> dict[str, list[int]]
     return events
 
 
-def _filter_event_types(event_types: list[EventType], mutable: bool) -> list[EventType]:
-    if mutable:
-        return [et for et in event_types if et.name not in IMMUTABLE_EVENTS]
-    else:
-        return [et for et in event_types if et.name in IMMUTABLE_EVENTS]
-
-
 class EventsPlugin(neon_player.Plugin):
     label = "Events"
     global_properties = EventsPluginGlobalProps()
@@ -220,8 +305,11 @@ class EventsPlugin(neon_player.Plugin):
         self._event_types_by_name: dict[str, EventType] = {}
         self._immutable_event_types: list[EventType] = []
         self._events: dict[str, list[int]] = {}
+
         self._consider_workspace = False
         self._batch_rename_job: BaseBackgroundJob | None = None
+        self._workspace_index: WorkspaceEventIndex = WorkspaceEventIndex()
+        self._index_file = "workspace-events.json"
 
         if self.headless:
             return
@@ -257,7 +345,8 @@ class EventsPlugin(neon_player.Plugin):
         are used as keys, the corresponding event types should always be accessible in the
         recording settings.
         """
-        plugin_state = self.app.session_settings.recording_settings.plugin_states.get(self.__class__.__name__, {})
+        recording_settings = self.app.session_settings.recording_settings
+        plugin_state = recording_settings.plugin_states.get(self.__class__.__name__, {})
         event_types_state = plugin_state.get("event_types", [])
         uid_name_mapping = {}
         event_names = [None] * len(event_types_state)
@@ -289,6 +378,61 @@ class EventsPlugin(neon_player.Plugin):
             events_changed = True
 
         return corrected_events, events_changed
+
+    def _load_workspace_index(self) -> None:
+        data = self.load_cached_json(self._index_file, workspace=True)
+        self._workspace_index.load(data)
+
+    def _save_workspace_index(self) -> None:
+        data = self._workspace_index.to_dict()
+        self.save_cached_json(self._index_file, data, workspace=True)
+
+    def _update_workspace_index(self, load: bool = True, save: bool = True) -> None:
+        if load:
+            self._load_workspace_index()
+        self._workspace_index.update(self.recording.id, self.events)
+        if save:
+            self._save_workspace_index()
+
+    def _scan_events_in_workspace(self):
+        # Update the index for the current recording to account for any changes
+        # outside of the workspace mode
+        self._update_workspace_index()
+
+        if self.headless:
+            self._on_workspace_event_scan_finished()
+            return
+
+        # If all recordings have already been scanned, update the UI immediately,
+        # otherwise launch a batch background job
+        workspace_recording_ids = {rec.id for rec in self.workspace.recordings}
+        scanned_recording_ids = self._workspace_index.recording_ids
+        missing_recording_ids = workspace_recording_ids - scanned_recording_ids
+        if not missing_recording_ids:
+            self._on_workspace_event_scan_finished()
+            return
+
+        recordings_to_scan = self.workspace.get_recordings_by_id(missing_recording_ids)
+        batch_job = self.job_manager.run_background_batch_action(
+            "Scan events in workspace",
+            "EventsPlugin._update_workspace_index",
+            recordings=recordings_to_scan
+        )
+        batch_job.finished.connect(EventsPlugin.instance()._on_workspace_event_scan_finished)
+
+    def _on_workspace_event_scan_finished(self):
+        self._load_workspace_index()
+
+        types_to_add = []
+        for event_name in self._workspace_index.events:
+            if event_name in self._event_types_by_name:
+                continue
+
+            types_to_add.append(EventType.from_name(event_name))
+
+        if types_to_add:
+            self.event_types = self.event_types + types_to_add
+            self._update_gui_for_event_types(event_types_to_add=types_to_add)
 
     def on_recording_loaded(self, recording: NeonRecording) -> None:
         try:
@@ -338,6 +482,8 @@ class EventsPlugin(neon_player.Plugin):
 
         batch_mode_enabled = getattr(self.app, "batch_mode_enabled", False)
         self._consider_workspace = batch_mode_enabled and self.workspace.size > 1
+        if self._consider_workspace:
+            self._scan_events_in_workspace()
 
         logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
         self._update_gui_for_event_types(event_types_to_add=event_types_to_setup_ui_for)

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -100,9 +100,12 @@ class EventType(PersistentPropertiesMixin, QObject):
         # but on the other hand, pass original name before the first change as
         # `old_name` to ensure correct modification, so we re-use the value from t
         # he pending debouncer if it exists
-        debouncer = SignalDebouncer.get_pending_debouncer(self.name_changed)
-        original_name = debouncer.args[0] if debouncer is not None else old_name
-        SignalDebouncer.debounce(self.name_changed, 1.5, original_name, value)
+        if plugin is not None:
+            debouncer = SignalDebouncer.get_pending_debouncer(self.name_changed)
+            original_name = debouncer.args[0] if debouncer is not None else old_name
+            SignalDebouncer.debounce(self.name_changed, 1.5, original_name, value)
+        else:
+            self.name_changed.emit(old_name, value)
 
     @property
     @property_params(max_length=1)
@@ -180,6 +183,7 @@ class EventTypeListWidget(ValueListWidget):
 def _load_events_from_recording(recording: NeonRecording):
     events: dict[str, list[int]] = {}
 
+    logging.debug("Loading events from Neon recording")
     for event_name in np.unique(recording.events.event):
         timestamps = recording.events[recording.events.event == event_name].time
         events[str(event_name)] = [int(t) for t in timestamps]
@@ -247,24 +251,77 @@ class EventsPlugin(neon_player.Plugin):
             if event_type.shortcut.lower() == key_text:
                 self._add_event(event_type)
 
+    def _ensure_correct_format(self, events: dict[str, list[int]]) -> tuple[dict[str, list[int]], bool]:
+        """
+        Ensure that the events dictionary has event names as keys, not unique IDs. If IDs
+        are used as keys, the corresponding event types should always be accessible in the
+        recording settings.
+        """
+        plugin_state = self.app.session_settings.recording_settings.plugin_states.get(self.__class__.__name__, {})
+        event_types_state = plugin_state.get("event_types", [])
+        uid_name_mapping = {}
+        event_names = [None] * len(event_types_state)
+        for idx, et in enumerate(event_types_state):
+            is_dict = isinstance(et, dict)
+            uid = et["uid"] if is_dict else et.uid
+            name = et["name"] if is_dict else et.name
+            uid_name_mapping[uid] = name
+            event_names[idx] = name
+
+        events_changed = False
+        corrected_events = {}
+        for key, value in events.items():
+            if key in IMMUTABLE_EVENTS:
+                corrected_events[key] = value
+                continue
+
+            # New format: keys are event names, keep them as is
+            if key in event_names:
+                corrected_events[key] = value
+                continue
+
+            # Old format: keys are event type UIDs, replace with event names
+            event_name = uid_name_mapping.get(key, None)
+            if event_name is None:
+                raise ValueError(f"Event type with UID '{key}' not found in recording settings")
+
+            corrected_events[event_name] = value
+            events_changed = True
+
+        return corrected_events, events_changed
+
     def on_recording_loaded(self, recording: NeonRecording) -> None:
         try:
             events = self.load_cached_json("events.json")
         except Exception:
-            logging.exception("Failed to load events json")
+            logging.exception("Failed to load events.json")
             events = None
 
         if events is None:
             events = _load_events_from_recording(recording)
+        else:
+            events, events_changed = self._ensure_correct_format(events)
+            if events_changed:
+                logging.debug("Replacing event type IDs with event names in the events.json file")
+                self.save_cached_json("events.json", events)
         self._events = events
 
         # NOTE: event types are loaded from plugin settings before this method is called,
-        # so existing event types need to be preserved while adding missing ones
+        # so existing event types need to be preserved while adding missing ones. If
+        # event type ID is different from the event name, make them match to align event
+        # types across recordings
         event_types_to_setup_ui_for = self.event_types
         event_types_changed = False
         for event_name in events:
-            if event_name in self._event_types_by_name or event_name in IMMUTABLE_EVENTS:
+            if event_name in IMMUTABLE_EVENTS:
                 continue
+
+            event_type = self._event_types_by_name.get(event_name, None)
+            if event_type is not None:
+                if event_type.uid != event_name:
+                    event_type.uid = event_name
+                    event_types_changed = True
+                    continue
 
             new_event_type = EventType.from_name(event_name)
             self._event_types_by_name[event_name] = new_event_type
@@ -532,7 +589,7 @@ class EventsPlugin(neon_player.Plugin):
         item_params={"label_field": "name"},
         prevent_add=True,
         primary=True,
-        scope=["recording", "workspace"],
+        scope=["workspace"],
     )
     def event_types(self) -> list[EventType]:
         return list(self._event_types_by_name.values())

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -82,13 +82,24 @@ class EventType(PersistentPropertiesMixin, QObject):
             )
             return
 
+        if plugin is not None and plugin._batch_rename_job is not None:
+            QMessageBox.warning(
+                None,
+                "Event rename in progress",
+                "Please wait for the current event rename operation to complete "
+                "before renaming the event again.",
+            )
+            return
+
         old_name = self._name
         self._name = value
         self._uid = value
 
-        # NOTE: if multiple name changes are made in quick succession, we need to
-        # original name before the first change passed as `old_name`, so we just
-        # update the pending debouncer args if it exists
+        # NOTE: if multiple name changes are made in quick succession, we need to,
+        # on the one hand, debounce the signal to avoid launching multiple bg jobs,
+        # but on the other hand, pass original name before the first change as
+        # `old_name` to ensure correct modification, so we re-use the value from t
+        # he pending debouncer if it exists
         debouncer = SignalDebouncer.get_pending_debouncer(self.name_changed)
         original_name = debouncer.args[0] if debouncer is not None else old_name
         SignalDebouncer.debounce(self.name_changed, 1.5, original_name, value)
@@ -630,11 +641,15 @@ class EventsPlugin(neon_player.Plugin):
             logging.warning(f"Event type '{old_name}' not found for renaming")
             return
 
+        if self._batch_rename_job is not None:
+            return
+
         # NOTE: While renaming the events, we need both the old and new names to be
         # present for events to load correctly. Once the renaming is complete, the
         # old name can be removed from the event types.
         self._event_types_by_name[new_name] = event_type
         self._event_types_by_name[old_name] = EventType.from_name(old_name)
+        self._rename_all_events_by_name(old_name, new_name)
         if not self.headless:
             timeline = self.get_timeline()
             plot_sorting_was_enabled = timeline.disable_plot_sorting()
@@ -649,9 +664,6 @@ class EventsPlugin(neon_player.Plugin):
         if not self._consider_workspace:
             self._rename_all_events_by_name(old_name, new_name)
             self._finalize_event_rename(old_name)
-            return
-
-        if self._batch_rename_job is not None:
             return
 
         self._batch_rename_job = self.job_manager.run_background_batch_action(

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -307,45 +307,61 @@ class EventsPlugin(neon_player.Plugin):
             if event_type.shortcut.lower() == key_text:
                 self._add_event(event_type)
 
-    def _ensure_correct_format(self, events: dict[str, list[int]]) -> tuple[dict[str, list[int]], bool]:
-        """
-        Ensure that the events dictionary has event names as keys, not unique IDs. If IDs
-        are used as keys, the corresponding event types should always be accessible in the
-        recording settings.
-        """
+    def _get_uid_name_mapping(self) -> dict[str, str]:
         recording_settings = self.app.session_settings.recording_settings
         plugin_state = recording_settings.plugin_states.get(self.__class__.__name__, {})
         event_types_state = plugin_state.get("event_types", [])
-        uid_name_mapping = {}
-        event_names = [None] * len(event_types_state)
-        for idx, et in enumerate(event_types_state):
-            is_dict = isinstance(et, dict)
-            uid = et["uid"] if is_dict else et.uid
-            name = et["name"] if is_dict else et.name
-            uid_name_mapping[uid] = name
-            event_names[idx] = name
 
-        events_changed = False
+        uid_name_mapping = {}
+        for et in event_types_state:
+            uid_name_mapping[et["uid"]] = et["name"]
+
+        return uid_name_mapping
+
+    def _load_events_from_cache(self) -> dict[str, list[int]] | None:
+        """
+        Load events from the cached JSON file. Ensure that the events dictionary has
+        event names as keys, not unique IDs. If IDs are used as keys, the corresponding
+        event names are derived from the recording settings.
+        """
+        try:
+            events = self.load_cached_json("events.json")
+        except Exception:
+            logging.exception("Failed to load events.json")
+            return None
+
+        if events is None:
+            return None
+
+        uid_name_mapping = self._get_uid_name_mapping()
         corrected_events = {}
+        events_changed = False
         for key, value in events.items():
             if key in IMMUTABLE_EVENTS:
                 corrected_events[key] = value
                 continue
 
             # New format: keys are event names, keep them as is
-            if key in event_names:
+            if key in self._event_types_by_name:
                 corrected_events[key] = value
                 continue
 
-            # Old format: keys are event type UIDs, replace with event names
-            event_name = uid_name_mapping.get(key, None)
-            if event_name is None:
-                raise ValueError(f"Event type with UID '{key}' not found in recording settings")
+            # Old format: keys are event type UIDs, replace with event names using
+            # the mapping based on recording settings
+            if key in uid_name_mapping:
+                event_name = uid_name_mapping[key]
+                corrected_events[event_name] = value
+                events_changed = True
+                continue
 
-            corrected_events[event_name] = value
-            events_changed = True
+            # Otherwise, keep the key as is, a corresponding event type will be created
+            corrected_events[key] = value
 
-        return corrected_events, events_changed
+        if events_changed:
+            logging.debug("Corrected event keys from UIDs to names in events.json")
+            self.save_cached_json("events.json", corrected_events)
+
+        return corrected_events
 
     def _load_workspace_index(self) -> None:
         data = self.load_cached_json(self._index_file, workspace=True)
@@ -416,19 +432,9 @@ class EventsPlugin(neon_player.Plugin):
             self._update_gui_for_event_types(event_types_to_add=types_to_add)
 
     def on_recording_loaded(self, recording: NeonRecording) -> None:
-        try:
-            events = self.load_cached_json("events.json")
-        except Exception:
-            logging.exception("Failed to load events.json")
-            events = None
-
+        events = self._load_events_from_cache()
         if events is None:
             events = _load_events_from_recording(recording)
-        # else:
-        #     events, events_changed = self._ensure_correct_format(events)
-        #     if events_changed:
-        #         logging.debug("Replacing event type IDs with event names in the events.json file")
-        #         self.save_cached_json("events.json", events)
         self._events = events
 
         # NOTE: event types are loaded from plugin settings before this method is called,

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -75,12 +75,12 @@ class EventType(PersistentPropertiesMixin, QObject):
         # NOTE: if multiple name changes are made in quick succession, we need to,
         # on the one hand, debounce the signal to avoid launching multiple bg jobs,
         # but on the other hand, pass original name before the first change as
-        # `old_name` to ensure correct modification, so we re-use the value from t
-        # he pending debouncer if it exists
-        if plugin is not None:
+        # `old_name` to ensure correct modification, so we re-use the value from
+        # the pending debouncer if it exists
+        if plugin is not None and plugin.batch_mode_enabled:
             debouncer = SignalDebouncer.get_pending_debouncer(self.name_changed)
             original_name = debouncer.args[0] if debouncer is not None else old_name
-            SignalDebouncer.debounce(self.name_changed, 1.5, original_name, value)
+            SignalDebouncer.debounce(self.name_changed, 1.0, original_name, value)
         else:
             self.name_changed.emit(old_name, value)
 
@@ -273,8 +273,8 @@ class EventsPlugin(neon_player.Plugin):
         self._events: dict[str, list[int]] = {}
 
         self._consider_workspace = False
-        self._batch_rename_job: BatchBackgroundJob | None = None
-        self._batch_delete_job: BatchBackgroundJob | None = None
+        self._batch_rename_job: dict[str, BatchBackgroundJob] = {}
+        self._batch_delete_job: dict[str, BatchBackgroundJob] = {}
         self._batch_update_job: BatchBackgroundJob | None = None
         self._workspace_index: WorkspaceEventIndex = WorkspaceEventIndex()
         self._index_file = "workspace-events.json"
@@ -425,6 +425,10 @@ class EventsPlugin(neon_player.Plugin):
         types_to_add = []
         for event_name in self._workspace_index.events:
             if event_name in self._event_types_by_name:
+                continue
+
+            # Hide event types that are being deleted across the workspace
+            if event_name in self._batch_delete_job:
                 continue
 
             types_to_add.append(EventType.from_name(event_name))
@@ -639,16 +643,17 @@ class EventsPlugin(neon_player.Plugin):
         if event_type.name not in self._event_types_by_name:
             return
 
+        del self._event_types_by_name[event_type.name]
+        self._delete_events_by_name(event_type.name)
+        self.changed.emit()
         if not self.headless:
             self._update_gui_for_event_types(event_types_to_remove=[event_type])
 
         if not self._consider_workspace:
-            self._delete_events_by_name(event_type.name)
-            self._delete_event_type(event_type)
             return
 
         warn_on_cancel = (
-            f"Cancelling this operation will leave the instances of event '{event_type.name}' "
+            f"Cancelling this operation will leave instances of event '{event_type.name}' "
             f"in an inconsistent state across recordings. Are you sure you want to cancel?"
         )
         batch_job = self.job_manager.run_background_batch_action(
@@ -657,13 +662,12 @@ class EventsPlugin(neon_player.Plugin):
             args_generator=lambda _: [event_type.name],
             warn_on_cancel=warn_on_cancel
         )
-        batch_job.finished.connect(lambda: self._delete_event_type(event_type))
-        self._batch_delete_job = batch_job
+        batch_job.finished.connect(lambda: self._on_batch_delete_finished(event_type))
+        batch_job.canceled.connect(lambda: self._on_batch_delete_finished(event_type))
+        self._batch_delete_job[event_type.name] = batch_job
 
-    def _delete_event_type(self, event_type: EventType) -> None:
-        self._batch_delete_job = None
-        del self._event_types_by_name[event_type.name]
-        self.changed.emit()
+    def _on_batch_delete_finished(self, event_type: EventType) -> None:
+        del self._batch_delete_job[event_type.name]
 
     def _delete_events_by_name(self, event_name: str) -> None:
         """

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -652,7 +652,7 @@ class EventsPlugin(neon_player.Plugin):
         if not self._consider_workspace:
             return
 
-        warn_on_cancel = (
+        confirm_cancel = (
             f"Cancelling this operation will leave instances of event '{event_type.name}' "
             f"in an inconsistent state across recordings. Are you sure you want to cancel?"
         )
@@ -660,7 +660,7 @@ class EventsPlugin(neon_player.Plugin):
             f"Delete events [{event_type.name}]",
             "EventsPlugin._delete_events_by_name",
             args_generator=lambda _: [event_type.name],
-            warn_on_cancel=warn_on_cancel
+            confirm_cancel=confirm_cancel
         )
         batch_job.finished.connect(lambda: self._on_batch_delete_finished(event_type))
         batch_job.canceled.connect(lambda: self._on_batch_delete_finished(event_type))

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -238,39 +238,6 @@ class WorkspaceEventIndex():
         if recording_id not in self.recording_ids:
             self.recording_ids.add(recording_id)
 
-    def add_event(self, recording_id: str, event_name: str) -> None:
-        if event_name not in self.events:
-            self.events[event_name] = {}
-
-        if recording_id not in self.events[event_name]:
-            self.events[event_name][recording_id] = 0
-
-    def delete_event(self, recording_id: str, event_name: str) -> None:
-        if event_name not in self.events or recording_id not in self.events[event_name]:
-            return
-
-        self.events[event_name][recording_id] -= 1
-
-        if self.events[event_name][recording_id] <= 0:
-            del self.events[event_name][recording_id]
-        if not self.events[event_name]:
-            del self.events[event_name]
-
-    def rename_event(self, recording_id: str, old_name: str, new_name: str) -> None:
-        if old_name not in self.events:
-            return
-
-        if new_name not in self.events:
-            self.events[new_name] = {}
-
-        self.events[new_name][recording_id] = self.events[old_name].pop(recording_id)
-        if not self.events[old_name]:
-            del self.events[old_name]
-
-    def delete_event_type(self, event_name: str) -> None:
-        if event_name in self.events:
-            del self.events[event_name]
-
 
 def _load_events_from_recording(recording: NeonRecording):
     events: dict[str, list[int]] = {}
@@ -308,6 +275,7 @@ class EventsPlugin(neon_player.Plugin):
 
         self._consider_workspace = False
         self._batch_rename_job: BaseBackgroundJob | None = None
+        self._batch_update_job: BaseBackgroundJob | None = None
         self._workspace_index: WorkspaceEventIndex = WorkspaceEventIndex()
         self._index_file = "workspace-events.json"
 
@@ -412,6 +380,11 @@ class EventsPlugin(neon_player.Plugin):
             self._on_workspace_event_scan_finished()
             return
 
+        # Skip scanning if it is already in progress, connected slot should update the
+        # event types in the UI once done
+        if self._batch_update_job is not None:
+            return
+
         recordings_to_scan = self.workspace.get_recordings_by_id(missing_recording_ids)
         batch_job = self.job_manager.run_background_batch_action(
             "Scan events in workspace",
@@ -419,8 +392,10 @@ class EventsPlugin(neon_player.Plugin):
             recordings=recordings_to_scan
         )
         batch_job.finished.connect(EventsPlugin.instance()._on_workspace_event_scan_finished)
+        self._batch_update_job = batch_job
 
     def _on_workspace_event_scan_finished(self):
+        self._batch_update_job = None
         self._load_workspace_index()
 
         types_to_add = []
@@ -433,6 +408,20 @@ class EventsPlugin(neon_player.Plugin):
         if types_to_add:
             self.event_types = self.event_types + types_to_add
             self._update_gui_for_event_types(event_types_to_add=types_to_add)
+
+    def _scan_current_jobs(self):
+        for job in self.job_manager.current_jobs:
+            plugin_name, action_name = job.action_name.split(".")
+            if plugin_name != self.__class__.__name__:
+                continue
+
+            if action_name == "_update_workspace_index":
+                self._batch_update_job = job
+                continue
+
+            if action_name == "_rename_all_events_by_name":
+                self._batch_rename_job = job
+                continue
 
     def on_recording_loaded(self, recording: NeonRecording) -> None:
         try:
@@ -483,6 +472,7 @@ class EventsPlugin(neon_player.Plugin):
         batch_mode_enabled = getattr(self.app, "batch_mode_enabled", False)
         self._consider_workspace = batch_mode_enabled and self.workspace.size > 1
         if self._consider_workspace:
+            self._scan_current_jobs()
             self._scan_events_in_workspace()
 
         logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
@@ -637,7 +627,7 @@ class EventsPlugin(neon_player.Plugin):
             "EventsPlugin._delete_events_by_name",
             lambda _: [event_type.name]
         )
-        batch_job.finished.connect(lambda: self._delete_event_type(event_type))
+        batch_job.finished.connect(lambda: EventsPlugin.instance()._delete_event_type(event_type))
 
     def _delete_event_type(self, event_type: EventType) -> None:
         del self._event_types_by_name[event_type.name]

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -153,7 +153,8 @@ class EventTypeListWidget(ValueListWidget):
                 return
 
         plugin.delete_event_type(event_type)
-        super().remove_item(item_widget)
+        self.container_layout.removeWidget(item_widget)
+        item_widget.deleteLater()
 
 
 def _load_events_from_recording(recording: NeonRecording):
@@ -238,6 +239,7 @@ class EventsPlugin(neon_player.Plugin):
         # NOTE: event types are loaded from plugin settings before this method is called,
         # so existing event types need to be preserved while adding missing ones
         event_types_to_setup_ui_for = self.event_types
+        event_types_changed = False
         for event_name in events:
             if event_name in self._event_types_by_name or event_name in IMMUTABLE_EVENTS:
                 continue
@@ -245,6 +247,9 @@ class EventsPlugin(neon_player.Plugin):
             new_event_type = EventType.from_name(event_name)
             self._event_types_by_name[event_name] = new_event_type
             event_types_to_setup_ui_for.append(new_event_type)
+            event_types_changed = True
+        if event_types_changed:
+            self.changed.emit()
 
         # Immutable event types are not stored in plugin settings but require UI
         self._immutable_event_types = [
@@ -368,12 +373,11 @@ class EventsPlugin(neon_player.Plugin):
 
     def create_event_type(self) -> EventType:
         event_type_counter = 1
-        candidate_name = ""
-        while candidate_name == "":
-            candidate_name = f"event-{event_type_counter}"
-            if candidate_name not in self._event_types_by_name:
-                return EventType.from_name(candidate_name)
+        candidate_name = f"event-{event_type_counter}"
+        while candidate_name in self._event_types_by_name:
             event_type_counter += 1
+            candidate_name = f"event-{event_type_counter}"
+        return EventType.from_name(candidate_name)
 
     def add_event_type(self, event_type: EventType) -> None:
         if event_type.name in self._event_types_by_name:
@@ -391,14 +395,42 @@ class EventsPlugin(neon_player.Plugin):
                 f"Event type {event_type.name} cannot be deleted."
             )
 
-        if event_type.uid in self._events:
-            del self._events[event_type.uid]
-            self.save_cached_json("events.json", self._events)
+        if event_type.name not in self._event_types_by_name:
+            return
 
-        if event_type.name in self._event_types_by_name:
-            del self._event_types_by_name[event_type.name]
-            self._update_gui_for_event_types(event_types_to_remove=[event_type])
-            self.changed.emit()
+        batch_mode_enabled = getattr(self.app, "batch_mode_enabled", False)
+        consider_workspace = batch_mode_enabled and self.workspace.size > 1
+        if not consider_workspace:
+            self._delete_events_by_name(event_type.name)
+            self._delete_event_type(event_type)
+            return
+
+        batch_job = self.job_manager.run_background_batch_action(
+            f"Delete event type [{event_type.name}]",
+            "EventsPlugin._delete_events_by_name",
+            lambda _: [event_type.name]
+        )
+        batch_job.finished.connect(lambda: self._delete_event_type(event_type))
+
+    def _delete_event_type(self, event_type: EventType) -> None:
+        del self._event_types_by_name[event_type.name]
+        self._update_gui_for_event_types(event_types_to_remove=[event_type])
+        self.changed.emit()
+
+    def _delete_events_by_name(self, event_name: str) -> None:
+        """
+        Background job to delete an event type in sibling recordings of the workspace.
+        The event type will be deleted from the current recording in the main process, so
+        the background job only needs to delete events of this type if they exist.
+        """
+        if event_name in IMMUTABLE_EVENTS:
+            return
+
+        if event_name not in self.events:
+            return
+
+        del self._events[event_name]
+        self.save_cached_json("events.json", self._events)
 
     def _add_event(self, event_type: EventType, ts: int | None = None) -> None:
         if self.recording is None:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -18,7 +18,7 @@ from qt_property_widgets.widgets import ValueListWidget, ValueListItemWidget
 
 from pupil_labs import neon_player
 from pupil_labs.neon_player import GlobalPluginProperties, action
-from pupil_labs.neon_player.job_manager import BaseBackgroundJob
+from pupil_labs.neon_player.job_manager import BatchBackgroundJob
 from pupil_labs.neon_player.plugins.shared import run_export_across_recordings
 from pupil_labs.neon_player.plugins import Plugin
 from pupil_labs.neon_player.ui import ListPropertyAppenderAction
@@ -65,30 +65,7 @@ class EventType(PersistentPropertiesMixin, QObject):
             return
 
         plugin = EventsPlugin.instance()
-        if plugin is not None and value in IMMUTABLE_EVENTS:
-            QMessageBox.warning(
-                None,
-                "Invalid event name",
-                f"Event cannot be renamed to '{value}' as this name is reserved. "
-                f"Please choose a different name.",
-            )
-            return
-
-        if plugin is not None and value in plugin._event_types_by_name:
-            QMessageBox.warning(
-                None,
-                "Duplicate event name",
-                f"Event '{value}' already exists. Please choose a different name.",
-            )
-            return
-
-        if plugin is not None and plugin._batch_rename_job is not None:
-            QMessageBox.warning(
-                None,
-                "Event rename in progress",
-                "Please wait for the current event rename operation to complete "
-                "before renaming the event again.",
-            )
+        if plugin is not None and not plugin.validate_event_name(value):
             return
 
         old_name = self._name
@@ -206,10 +183,16 @@ class WorkspaceEventIndex():
         }
         return data
 
+    def _cleanup_events(self) -> None:
+        """
+        Clean up any events that no longer exist in any recordings.
+        """
+        self.events = {k: v for k, v in self.events.items() if v}
+
     def update(self, recording_id: str, recording_events: dict[str, list[int]]) -> None:
         """
-        Batch index update that goes through all events in the index and all
-        recording events.
+        Batch index update that goes through all events in the index and all events
+        that belong to a particular recording.
         """
         # First, check if existing index entries for this recording are up-to-date
         for event_name, recording_counts in self.events.items():
@@ -222,6 +205,8 @@ class WorkspaceEventIndex():
             if event_in_recording:
                 timestamps = recording_events[event_name]
                 self.events[event_name][recording_id] = len(timestamps)
+
+        self._cleanup_events()
 
         # Process other events from the recording that are not yet in the index
         for event_name, timestamps in recording_events.items():
@@ -237,6 +222,20 @@ class WorkspaceEventIndex():
         # Mark recording as processed in the index
         if recording_id not in self.recording_ids:
             self.recording_ids.add(recording_id)
+
+    def drop(self, recording_id: str) -> None:
+        """
+        Remove all events from the index that belong to a particular recording.
+        """
+        if recording_id not in self.recording_ids:
+            return
+
+        for recording_counts in self.events.values():
+            if recording_id in recording_counts:
+                del recording_counts[recording_id]
+
+        self._cleanup_events()
+        self.recording_ids.remove(recording_id)
 
 
 def _load_events_from_recording(recording: NeonRecording):
@@ -274,8 +273,9 @@ class EventsPlugin(neon_player.Plugin):
         self._events: dict[str, list[int]] = {}
 
         self._consider_workspace = False
-        self._batch_rename_job: BaseBackgroundJob | None = None
-        self._batch_update_job: BaseBackgroundJob | None = None
+        self._batch_rename_job: BatchBackgroundJob | None = None
+        self._batch_delete_job: BatchBackgroundJob | None = None
+        self._batch_update_job: BatchBackgroundJob | None = None
         self._workspace_index: WorkspaceEventIndex = WorkspaceEventIndex()
         self._index_file = "workspace-events.json"
 
@@ -363,6 +363,11 @@ class EventsPlugin(neon_player.Plugin):
             self._save_workspace_index()
 
     def _scan_events_in_workspace(self):
+        # Skip scanning if it is already in progress, connected slot should update the
+        # event types in the UI once done
+        if self._batch_update_job is not None:
+            return
+
         # Update the index for the current recording to account for any changes
         # outside of the workspace mode
         self._update_workspace_index()
@@ -371,18 +376,19 @@ class EventsPlugin(neon_player.Plugin):
             self._on_workspace_event_scan_finished()
             return
 
-        # If all recordings have already been scanned, update the UI immediately,
-        # otherwise launch a batch background job
         workspace_recording_ids = {rec.id for rec in self.workspace.recordings}
         scanned_recording_ids = self._workspace_index.recording_ids
+
+        # Remove any recordings from the index that no longer exist in the workspace
+        outdated_recording_ids = scanned_recording_ids - workspace_recording_ids
+        for recording_id in outdated_recording_ids:
+            self._workspace_index.drop(recording_id)
+
+        # If all recordings have already been scanned, update the UI immediately,
+        # otherwise launch a batch background job
         missing_recording_ids = workspace_recording_ids - scanned_recording_ids
         if not missing_recording_ids:
             self._on_workspace_event_scan_finished()
-            return
-
-        # Skip scanning if it is already in progress, connected slot should update the
-        # event types in the UI once done
-        if self._batch_update_job is not None:
             return
 
         recordings_to_scan = self.workspace.get_recordings_by_id(missing_recording_ids)
@@ -391,7 +397,7 @@ class EventsPlugin(neon_player.Plugin):
             "EventsPlugin._update_workspace_index",
             recordings=recordings_to_scan
         )
-        batch_job.finished.connect(EventsPlugin.instance()._on_workspace_event_scan_finished)
+        batch_job.finished.connect(self._on_workspace_event_scan_finished)
         self._batch_update_job = batch_job
 
     def _on_workspace_event_scan_finished(self):
@@ -409,20 +415,6 @@ class EventsPlugin(neon_player.Plugin):
             self.event_types = self.event_types + types_to_add
             self._update_gui_for_event_types(event_types_to_add=types_to_add)
 
-    def _scan_current_jobs(self):
-        for job in self.job_manager.current_jobs:
-            plugin_name, action_name = job.action_name.split(".")
-            if plugin_name != self.__class__.__name__:
-                continue
-
-            if action_name == "_update_workspace_index":
-                self._batch_update_job = job
-                continue
-
-            if action_name == "_rename_all_events_by_name":
-                self._batch_rename_job = job
-                continue
-
     def on_recording_loaded(self, recording: NeonRecording) -> None:
         try:
             events = self.load_cached_json("events.json")
@@ -432,11 +424,11 @@ class EventsPlugin(neon_player.Plugin):
 
         if events is None:
             events = _load_events_from_recording(recording)
-        else:
-            events, events_changed = self._ensure_correct_format(events)
-            if events_changed:
-                logging.debug("Replacing event type IDs with event names in the events.json file")
-                self.save_cached_json("events.json", events)
+        # else:
+        #     events, events_changed = self._ensure_correct_format(events)
+        #     if events_changed:
+        #         logging.debug("Replacing event type IDs with event names in the events.json file")
+        #         self.save_cached_json("events.json", events)
         self._events = events
 
         # NOTE: event types are loaded from plugin settings before this method is called,
@@ -469,10 +461,8 @@ class EventsPlugin(neon_player.Plugin):
         ]
         event_types_to_setup_ui_for.extend(self._immutable_event_types)
 
-        batch_mode_enabled = getattr(self.app, "batch_mode_enabled", False)
-        self._consider_workspace = batch_mode_enabled and self.workspace.size > 1
+        self._consider_workspace = self.batch_mode_enabled and self.workspace.size > 1
         if self._consider_workspace:
-            self._scan_current_jobs()
             self._scan_events_in_workspace()
 
         logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
@@ -595,6 +585,35 @@ class EventsPlugin(neon_player.Plugin):
             candidate_name = f"event-{event_type_counter}"
         return EventType.from_name(candidate_name)
 
+    def validate_event_name(self, name: str) -> bool:
+        if name in IMMUTABLE_EVENTS:
+            QMessageBox.warning(
+                None,
+                "Invalid event name",
+                f"Event cannot be renamed to '{name}' as this name is reserved. "
+                f"Please choose a different name.",
+            )
+            return False
+
+        if name in self._event_types_by_name:
+            QMessageBox.warning(
+                None,
+                "Duplicate event name",
+                f"Event '{name}' already exists. Please choose a different name.",
+            )
+            return False
+
+        if self._batch_rename_job is not None:
+            QMessageBox.warning(
+                None,
+                "Event rename in progress",
+                "Please wait for the current event rename operation to complete "
+                "before renaming the event again.",
+            )
+            return False
+
+        return True
+
     def add_event_type(self, event_type: EventType) -> None:
         if event_type.name in self._event_types_by_name:
             raise ValueError(
@@ -622,14 +641,21 @@ class EventsPlugin(neon_player.Plugin):
             self._delete_event_type(event_type)
             return
 
+        warn_on_cancel = (
+            f"Cancelling this operation will leave the instances of event '{event_type.name}' "
+            f"in an inconsistent state across recordings. Are you sure you want to cancel?"
+        )
         batch_job = self.job_manager.run_background_batch_action(
             f"Delete events [{event_type.name}]",
             "EventsPlugin._delete_events_by_name",
-            lambda _: [event_type.name]
+            args_generator=lambda _: [event_type.name],
+            warn_on_cancel=warn_on_cancel
         )
-        batch_job.finished.connect(lambda: EventsPlugin.instance()._delete_event_type(event_type))
+        batch_job.finished.connect(lambda: self._delete_event_type(event_type))
+        self._batch_delete_job = batch_job
 
     def _delete_event_type(self, event_type: EventType) -> None:
+        self._batch_delete_job = None
         del self._event_types_by_name[event_type.name]
         self.changed.emit()
 
@@ -647,6 +673,7 @@ class EventsPlugin(neon_player.Plugin):
 
         logging.debug(f"Deleting all instances of event '{event_name}'")
         del self._events[event_name]
+        self._update_workspace_index()
         self.save_cached_json("events.json", self._events)
 
     def _add_event(self, event_type: EventType, ts: int | None = None) -> None:
@@ -776,6 +803,8 @@ class EventsPlugin(neon_player.Plugin):
             self._events[event_type.uid].extend(timestamps)
 
         self.save_cached_json("events.json", self._events)
+        self._update_workspace_index()
+
         self._update_gui_for_event_types(event_types_to_add=event_types_to_add)
         if event_types_to_add:
             self.changed.emit()
@@ -821,6 +850,8 @@ class EventsPlugin(neon_player.Plugin):
                 event_types_to_update.append(event_type)
 
         self.save_cached_json("events.json", self._events)
+        self._update_workspace_index()
+
         if event_types_to_remove:
             self._update_gui_for_event_types(event_types_to_remove=event_types_to_remove)
             self.changed.emit()
@@ -872,6 +903,7 @@ class EventsPlugin(neon_player.Plugin):
 
         self._events[new_name] = self._events.pop(old_name)
         self.save_cached_json("events.json", self._events)
+        self._update_workspace_index()
 
     def _finalize_event_rename(self, old_name: str) -> None:
         if old_name in self._event_types_by_name:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -18,9 +18,11 @@ from qt_property_widgets.widgets import ValueListWidget, ValueListItemWidget
 
 from pupil_labs import neon_player
 from pupil_labs.neon_player import GlobalPluginProperties, action
+from pupil_labs.neon_player.job_manager import BaseBackgroundJob
 from pupil_labs.neon_player.plugins.shared import run_export_across_recordings
 from pupil_labs.neon_player.plugins import Plugin
 from pupil_labs.neon_player.ui import ListPropertyAppenderAction
+from pupil_labs.neon_player.utilities import SignalDebouncer
 
 IMMUTABLE_EVENTS = ["recording.begin", "recording.end"]
 
@@ -82,7 +84,14 @@ class EventType(PersistentPropertiesMixin, QObject):
 
         old_name = self._name
         self._name = value
-        self.name_changed.emit(old_name, value)
+        self._uid = value
+
+        # NOTE: if multiple name changes are made in quick succession, we need to
+        # original name before the first change passed as `old_name`, so we just
+        # update the pending debouncer args if it exists
+        debouncer = SignalDebouncer.get_pending_debouncer(self.name_changed)
+        original_name = debouncer.args[0] if debouncer is not None else old_name
+        SignalDebouncer.debounce(self.name_changed, 1.5, original_name, value)
 
     @property
     @property_params(max_length=1)
@@ -196,6 +205,8 @@ class EventsPlugin(neon_player.Plugin):
         self._event_types_by_name: dict[str, EventType] = {}
         self._immutable_event_types: list[EventType] = []
         self._events: dict[str, list[int]] = {}
+        self._consider_workspace = False
+        self._batch_rename_job: BaseBackgroundJob | None = None
 
         if self.headless:
             return
@@ -257,6 +268,9 @@ class EventsPlugin(neon_player.Plugin):
         ]
         event_types_to_setup_ui_for.extend(self._immutable_event_types)
 
+        batch_mode_enabled = getattr(self.app, "batch_mode_enabled", False)
+        self._consider_workspace = batch_mode_enabled and self.workspace.size > 1
+
         logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
         self._update_gui_for_event_types(event_types_to_add=event_types_to_setup_ui_for)
 
@@ -284,9 +298,7 @@ class EventsPlugin(neon_player.Plugin):
 
         for et in event_types_to_add:
             et.changed.connect(self.changed.emit)
-            et.name_changed.connect(
-                lambda old, new, et=et: self._on_event_name_changed(old, new, et)
-            )
+            et.name_changed.connect(self._on_event_name_changed)
             self._setup_gui_for_event_type(et)
             self._update_timeline_data(et)
 
@@ -398,15 +410,16 @@ class EventsPlugin(neon_player.Plugin):
         if event_type.name not in self._event_types_by_name:
             return
 
-        batch_mode_enabled = getattr(self.app, "batch_mode_enabled", False)
-        consider_workspace = batch_mode_enabled and self.workspace.size > 1
-        if not consider_workspace:
+        if not self.headless:
+            self._update_gui_for_event_types(event_types_to_remove=[event_type])
+
+        if not self._consider_workspace:
             self._delete_events_by_name(event_type.name)
             self._delete_event_type(event_type)
             return
 
         batch_job = self.job_manager.run_background_batch_action(
-            f"Delete event type [{event_type.name}]",
+            f"Delete events [{event_type.name}]",
             "EventsPlugin._delete_events_by_name",
             lambda _: [event_type.name]
         )
@@ -414,7 +427,6 @@ class EventsPlugin(neon_player.Plugin):
 
     def _delete_event_type(self, event_type: EventType) -> None:
         del self._event_types_by_name[event_type.name]
-        self._update_gui_for_event_types(event_types_to_remove=[event_type])
         self.changed.emit()
 
     def _delete_events_by_name(self, event_name: str) -> None:
@@ -429,6 +441,7 @@ class EventsPlugin(neon_player.Plugin):
         if event_name not in self.events:
             return
 
+        logging.debug(f"Deleting all instances of event '{event_name}'")
         del self._events[event_name]
         self.save_cached_json("events.json", self._events)
 
@@ -610,24 +623,56 @@ class EventsPlugin(neon_player.Plugin):
         for event_type in event_types_to_update:
             self._update_timeline_data(event_type)
 
-    def _on_event_name_changed(
-        self, old_name: str, new_name: str, event_type: EventType
-    ) -> None:
-        self._event_types_by_name[new_name] = event_type
-        del self._event_types_by_name[old_name]
-
-        if self.headless:
+    def _on_event_name_changed(self, old_name: str, new_name: str) -> None:
+        logging.info(f"Renaming event '{old_name}' to '{new_name}'")
+        event_type = self._event_types_by_name.pop(old_name, None)
+        if event_type is None:
+            logging.warning(f"Event type '{old_name}' not found for renaming")
             return
 
-        timeline = self.get_timeline()
-        plot_sorting_was_enabled = timeline.disable_plot_sorting()
+        # NOTE: While renaming the events, we need both the old and new names to be
+        # present for events to load correctly. Once the renaming is complete, the
+        # old name can be removed from the event types.
+        self._event_types_by_name[new_name] = event_type
+        self._event_types_by_name[old_name] = EventType.from_name(old_name)
+        if not self.headless:
+            timeline = self.get_timeline()
+            plot_sorting_was_enabled = timeline.disable_plot_sorting()
 
-        self._remove_gui_for_event_name(old_name)
-        self._setup_gui_for_event_type(event_type)
-        self._update_timeline_data(event_type)
+            self._remove_gui_for_event_name(old_name)
+            self._setup_gui_for_event_type(event_type)
+            self._update_timeline_data(event_type)
 
-        if plot_sorting_was_enabled:
-            timeline.enable_plot_sorting()
+            if plot_sorting_was_enabled:
+                timeline.enable_plot_sorting()
+
+        if not self._consider_workspace:
+            self._rename_all_events_by_name(old_name, new_name)
+            self._finalize_event_rename(old_name)
+            return
+
+        if self._batch_rename_job is not None:
+            return
+
+        self._batch_rename_job = self.job_manager.run_background_batch_action(
+            f"Rename events [{old_name} -> {new_name}]",
+            "EventsPlugin._rename_all_events_by_name",
+            lambda _: [old_name, new_name]
+        )
+        self._batch_rename_job.finished.connect(lambda: self._finalize_event_rename(old_name))
+
+    def _rename_all_events_by_name(self, old_name: str, new_name: str) -> None:
+        if old_name not in self._events:
+            return
+
+        self._events[new_name] = self._events.pop(old_name)
+        self.save_cached_json("events.json", self._events)
+
+    def _finalize_event_rename(self, old_name: str) -> None:
+        if old_name in self._event_types_by_name:
+            del self._event_types_by_name[old_name]
+        self.changed.emit()
+        self._batch_rename_job = None
 
     @action
     @action_params(

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -408,6 +408,7 @@ class EventsPlugin(neon_player.Plugin):
             return
 
         recordings_to_scan = self.workspace.get_recordings_by_id(missing_recording_ids)
+        logging.info(f"Scanning events in {len(recordings_to_scan)} recordings of the workspace")
         batch_job = self.job_manager.run_background_batch_action(
             "Scan events in workspace",
             "EventsPlugin._update_workspace_index",
@@ -419,6 +420,7 @@ class EventsPlugin(neon_player.Plugin):
     def _on_workspace_event_scan_finished(self):
         self._batch_update_job = None
         self._load_workspace_index()
+        logging.info("Finished scanning events in workspace recordings")
 
         types_to_add = []
         for event_name in self._workspace_index.events:
@@ -436,28 +438,27 @@ class EventsPlugin(neon_player.Plugin):
         if events is None:
             events = _load_events_from_recording(recording)
         self._events = events
+        logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
 
         # NOTE: event types are loaded from plugin settings before this method is called,
-        # so existing event types need to be preserved while adding missing ones. If
-        # event type ID is different from the event name, make them match to align event
-        # types across recordings
-        event_types_to_setup_ui_for = self.event_types
-        event_types_changed = False
+        # so existing event types need to be preserved while adding missing ones.
         for event_name in events:
             if event_name in IMMUTABLE_EVENTS:
                 continue
 
-            event_type = self._event_types_by_name.get(event_name, None)
-            if event_type is not None:
-                if event_type.uid != event_name:
-                    event_type.uid = event_name
-                    event_types_changed = True
-                    continue
+            if event_name in self._event_types_by_name:
+                continue
 
             new_event_type = EventType.from_name(event_name)
             self._event_types_by_name[event_name] = new_event_type
-            event_types_to_setup_ui_for.append(new_event_type)
-            event_types_changed = True
+
+        # If event type ID is different from the event name, make them match to
+        # align event types across recordings
+        event_types_changed = False
+        for event_type in self._event_types_by_name.values():
+            if event_type.uid != event_type.name:
+                event_type.uid = event_type.name
+                event_types_changed = True
         if event_types_changed:
             self.changed.emit()
 
@@ -465,13 +466,12 @@ class EventsPlugin(neon_player.Plugin):
         self._immutable_event_types = [
             EventType.from_name(event_name) for event_name in IMMUTABLE_EVENTS
         ]
-        event_types_to_setup_ui_for.extend(self._immutable_event_types)
+        event_types_to_setup_ui_for = self._immutable_event_types + self.event_types
 
         self._consider_workspace = self.batch_mode_enabled and self.workspace.size > 1
         if self._consider_workspace:
             self._scan_events_in_workspace()
 
-        logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
         self._update_gui_for_event_types(event_types_to_add=event_types_to_setup_ui_for)
 
     def on_disabled(self) -> None:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -2,7 +2,6 @@ import logging
 import numpy as np
 import pandas as pd
 import typing as T
-import uuid
 
 from pathlib import Path
 from pupil_labs.neon_recording import NeonRecording
@@ -49,6 +48,10 @@ class EventType(PersistentPropertiesMixin, QObject):
         self._name = ""
         self._shortcut = ""
         self._uid = ""
+
+    def __repr__(self) -> str:
+        shortcut_str = f", shortcut={self._shortcut}" if self._shortcut else ""
+        return f"EventType({self._name}{shortcut_str})"
 
     @property
     def name(self) -> str:
@@ -103,7 +106,7 @@ class EventType(PersistentPropertiesMixin, QObject):
     def from_name(name: str) -> "EventType":
         et = EventType()
         et._name = name
-        et._uid = name if name in IMMUTABLE_EVENTS else str(uuid.uuid4())
+        et._uid = name
         return et
 
 
@@ -153,67 +156,14 @@ class EventTypeListWidget(ValueListWidget):
         super().remove_item(item_widget)
 
 
-def _load_events_from_recording(
-    recording: NeonRecording, global_event_types: list[str] = []
-) -> tuple[list[EventType], dict[str, list[int]]]:
-    """
-    Loads events from the recording and additionally creates event types that
-    are defined in global settings.
-
-    Returns all created event types and the events as {uid: list of timestamps}.
-    """
-    event_type_cache: dict[str, EventType] = {}
+def _load_events_from_recording(recording: NeonRecording):
     events: dict[str, list[int]] = {}
 
-    for event in recording.events:
-        event_name = str(event.event)
+    for event_name in np.unique(recording.events.event):
+        timestamps = recording.events[recording.events.event == event_name].time
+        events[str(event_name)] = [int(t) for t in timestamps]
 
-        # Look up or create the event type
-        et = event_type_cache.get(event_name, None)
-        if et is None:
-            et = EventType.from_name(event_name)
-            event_type_cache[event_name] = et
-
-        # Add event to the dictionary
-        if et.uid not in events:
-            events[et.uid] = []
-        events[et.uid].append(int(event.time))
-
-    for event_name in global_event_types:
-        if event_name in event_type_cache:
-            continue
-
-        event_type_cache[event_name] = EventType.from_name(event_name)
-
-    return list(event_type_cache.values()), events
-
-
-def _load_events_from_cache(
-    cached_events: dict, known_event_types: list[EventType]
-) -> tuple[list[EventType], dict]:
-    """
-    Load event data from a cache stored in events.json. All event types are expected
-    to either be immutable (recording.begin, recording.end) or have been previously
-    defined and stored in the known_event_types list.
-
-    Returns event types that are present in the cache as well as events themselves.
-    """
-    known_event_types_by_uid = {et.uid: et for et in known_event_types}
-    for event_name in IMMUTABLE_EVENTS:
-        et = EventType.from_name(event_name)
-        known_event_types_by_uid[et.uid] = et
-
-    event_type_cache = {}
-    for uid in cached_events:
-        if uid in event_type_cache:
-            continue
-
-        if uid not in known_event_types_by_uid:
-            raise ValueError(f"Event type with uid {uid} not found")
-
-        event_type_cache[uid] = known_event_types_by_uid[uid]
-
-    return list(event_type_cache.values()), cached_events
+    return events
 
 
 def _load_events_from_dataframe(events_df: pd.DataFrame) -> dict[str, list[int]]:
@@ -274,49 +224,35 @@ class EventsPlugin(neon_player.Plugin):
             if event_type.shortcut.lower() == key_text:
                 self._add_event(event_type)
 
-    def _load_events(self, recording: NeonRecording) -> tuple[list[EventType], dict, str]:
-        events: dict[str, list[int]] = {}
-        event_types: list[EventType] = []
-
+    def on_recording_loaded(self, recording: NeonRecording) -> None:
         try:
-            cached_events = self.load_cached_json("events.json")
+            events = self.load_cached_json("events.json")
         except Exception:
             logging.exception("Failed to load events json")
-            cached_events = None
+            events = None
 
-        if cached_events is not None:
-            event_types, events = _load_events_from_cache(
-                cached_events, list(self._event_types_by_name.values())
-            )
-            return event_types, events, "cache"
-
-        event_types, events = _load_events_from_recording(
-            recording, self.global_properties.global_event_types
-        )
-
-        return event_types, events, "recording"
-
-    def on_recording_loaded(self, recording: NeonRecording) -> None:  # noqa: C901
-        event_types, events, source = self._load_events(recording)
+        if events is None:
+            events = _load_events_from_recording(recording)
         self._events = events
 
-        if source == "recording":
-            # When loading from recording, only mutable event types need to be saved,
-            # but the UI needs to be set up for all event types
-            mutable_event_types = _filter_event_types(event_types, mutable=True)
-            self._immutable_event_types = _filter_event_types(event_types, mutable=False)
-            event_types_to_setup_ui_for = event_types
-            self.event_types = mutable_event_types
-            self.save_cached_json("events.json", events)
-        elif source == "cache":
-            # When loading from cache, all event types are expected to have been loaded
-            # from plugin settings, so self.event_types is already correct, but the UI
-            # still needs to be set up for stored and immutable event types
-            self._immutable_event_types = _filter_event_types(event_types, mutable=False)
-            event_types_to_setup_ui_for = self.event_types + self._immutable_event_types
+        # NOTE: event types are loaded from plugin settings before this method is called,
+        # so existing event types need to be preserved while adding missing ones
+        event_types_to_setup_ui_for = self.event_types
+        for event_name in events:
+            if event_name in self._event_types_by_name or event_name in IMMUTABLE_EVENTS:
+                continue
+
+            new_event_type = EventType.from_name(event_name)
+            self._event_types_by_name[event_name] = new_event_type
+            event_types_to_setup_ui_for.append(new_event_type)
+
+        # Immutable event types are not stored in plugin settings but require UI
+        self._immutable_event_types = [
+            EventType.from_name(event_name) for event_name in IMMUTABLE_EVENTS
+        ]
+        event_types_to_setup_ui_for.extend(self._immutable_event_types)
 
         logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
-
         self._update_gui_for_event_types(event_types_to_add=event_types_to_setup_ui_for)
 
     def on_disabled(self) -> None:
@@ -431,17 +367,13 @@ class EventsPlugin(neon_player.Plugin):
         self.app.main_window.remove_menu_if_empty("Timeline/Add Event")
 
     def create_event_type(self) -> EventType:
-        new_event_type = EventType()
-        new_event_type.uid = str(uuid.uuid4())
-
         event_type_counter = 1
-        while new_event_type.name == "":
+        candidate_name = ""
+        while candidate_name == "":
             candidate_name = f"event-{event_type_counter}"
             if candidate_name not in self._event_types_by_name:
-                new_event_type.name = candidate_name
+                return EventType.from_name(candidate_name)
             event_type_counter += 1
-
-        return new_event_type
 
     def add_event_type(self, event_type: EventType) -> None:
         if event_type.name in self._event_types_by_name:
@@ -544,7 +476,7 @@ class EventsPlugin(neon_player.Plugin):
         item_params={"label_field": "name"},
         prevent_add=True,
         primary=True,
-        scope="recording",
+        scope=["recording", "workspace"],
     )
     def event_types(self) -> list[EventType]:
         return list(self._event_types_by_name.values())

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -935,7 +935,7 @@ class EventsPlugin(neon_player.Plugin):
         if not self._consider_workspace:
             return
 
-        _, recording_ids = self._count_events_across_workspace(event_type.name)
+        _, recording_ids = self._count_events_across_workspace(old_name)
         other_recording_ids = set(recording_ids) - {self.recording.id}
         other_recordings = self.workspace.get_recordings_by_id(other_recording_ids)
         if not other_recordings:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -147,16 +147,8 @@ class EventTypeListWidget(ValueListWidget):
             return
 
         event_type = item_widget.item_widget.value
-        events = plugin._events.get(event_type.uid, [])
-        if events:
-            suffix = "" if len(events) == 1 else "s"
-            confirmed = plugin.user_confirm(
-                "Confirm event type deletion",
-                f"Deleting event type '{event_type.name}' will also delete its {len(events)}"
-                f" instance{suffix}. Do you want to proceed?",
-            )
-            if not confirmed:
-                return
+        if not plugin.confirm_event_type_removal(event_type.name):
+            return
 
         plugin.delete_event_type(event_type)
         self.container_layout.removeWidget(item_widget)
@@ -443,6 +435,19 @@ class EventsPlugin(neon_player.Plugin):
             self.event_types = self.event_types + types_to_add
             self._update_gui_for_event_types(event_types_to_add=types_to_add)
 
+    def _count_events_across_workspace(self, event_name: str) -> tuple[int, list[str]]:
+        """
+        Returns the total number of occurrences of a given event across all
+        recordings in the workspace, along with a list of recording IDs that
+        contain this event.
+        """
+        if not self.batch_mode_enabled:
+            events = self.events.get(event_name, [])
+            return len(events), [self.recording._rec_dir.name] if events else []
+
+        event_occurrences = self._workspace_index.events.get(event_name, {})
+        return sum(event_occurrences.values()), list(event_occurrences.keys())
+
     def on_recording_loaded(self, recording: NeonRecording) -> None:
         events = self._load_events_from_cache()
         if events is None:
@@ -639,6 +644,29 @@ class EventsPlugin(neon_player.Plugin):
         self._event_types_by_name[event_type.name] = event_type
         self._update_gui_for_event_types(event_types_to_add=[event_type])
         self.changed.emit()
+
+    def confirm_event_type_removal(self, event_name: str) -> bool:
+        num_events, recording_ids = self._count_events_across_workspace(event_name)
+        if not num_events:
+            return True
+
+        recordings_desc = ""
+        assert recording_ids, "Recording IDs should not be empty when num_events > 0"
+        if len(recording_ids) > 1:
+            recordings_desc = f" across {len(recording_ids)} recordings in the workspace"
+        elif recording_ids[0] == self.recording.id:
+            recordings_desc = " in the current recording"
+        else:
+            other_rec = self.workspace.get_recordings_by_id([recording_ids[0]])
+            recordings_desc = f" in the recording '{other_rec[0]._rec_dir.name}'"
+
+        suffix = "" if num_events == 1 else "s"
+        confirmed = self.user_confirm(
+            "Confirm event type deletion",
+            f"Deleting event type '{event_name}' will also delete its {num_events}"
+            f" instance{suffix}{recordings_desc}. Do you want to proceed?",
+        )
+        return confirmed
 
     def delete_event_type(self, event_type: EventType) -> None:
         if event_type.name in IMMUTABLE_EVENTS:

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -64,11 +64,11 @@ class EventType(PersistentPropertiesMixin, QObject):
         if self._name == value:
             return
 
+        old_name = self._name
         plugin = EventsPlugin.instance()
-        if plugin is not None and not plugin.validate_event_name(value):
+        if plugin is not None and not plugin.validate_event_rename(old_name, value):
             return
 
-        old_name = self._name
         self._name = value
         self._uid = value
 
@@ -96,6 +96,12 @@ class EventType(PersistentPropertiesMixin, QObject):
     @property
     @property_params(widget=None)
     def uid(self) -> str:
+        """
+        This property is deprecated and should always have the same value as `name`.
+
+        It is kept for compatibility with the original implementation of the plugin
+        that used UIDs as the primary identifier for event types.
+        """
         return self._uid
 
     @uid.setter
@@ -595,30 +601,30 @@ class EventsPlugin(neon_player.Plugin):
             candidate_name = f"event-{event_type_counter}"
         return EventType.from_name(candidate_name)
 
-    def validate_event_name(self, name: str) -> bool:
-        if name in IMMUTABLE_EVENTS:
+    def validate_event_rename(self, old_name: str, new_name: str) -> bool:
+        if new_name in IMMUTABLE_EVENTS:
             QMessageBox.warning(
                 None,
                 "Invalid event name",
-                f"Event cannot be renamed to '{name}' as this name is reserved. "
+                f"Event cannot be renamed to '{new_name}' as this name is reserved. "
                 f"Please choose a different name.",
             )
             return False
 
-        if name in self._event_types_by_name:
+        if new_name in self._event_types_by_name:
             QMessageBox.warning(
                 None,
                 "Duplicate event name",
-                f"Event '{name}' already exists. Please choose a different name.",
+                f"Event '{new_name}' already exists. Please choose a different name.",
             )
             return False
 
-        if self._batch_rename_job is not None:
+        if old_name in self._batch_rename_job:
             QMessageBox.warning(
                 None,
                 "Event rename in progress",
-                "Please wait for the current event rename operation to complete "
-                "before renaming the event again.",
+                f"Please wait for the current event rename operation to complete "
+                f"before renaming the event '{old_name}' again.",
             )
             return False
 
@@ -652,19 +658,21 @@ class EventsPlugin(neon_player.Plugin):
         if not self._consider_workspace:
             return
 
-        confirm_cancel = (
-            f"Cancelling this operation will leave instances of event '{event_type.name}' "
-            f"in an inconsistent state across recordings. Are you sure you want to cancel?"
-        )
         batch_job = self.job_manager.run_background_batch_action(
             f"Delete events [{event_type.name}]",
             "EventsPlugin._delete_events_by_name",
             args_generator=lambda _: [event_type.name],
-            confirm_cancel=confirm_cancel
+            confirm_cancel=self.confirm_cancel_message(event_type.name),
         )
         batch_job.finished.connect(lambda: self._on_batch_delete_finished(event_type))
         batch_job.canceled.connect(lambda: self._on_batch_delete_finished(event_type))
         self._batch_delete_job[event_type.name] = batch_job
+
+    def confirm_cancel_message(self, event_name: str) -> str:
+        return (
+            f"Cancelling this operation will leave instances of event '{event_name}' "
+            f"in an inconsistent state across recordings. Are you sure you want to cancel?"
+        )
 
     def _on_batch_delete_finished(self, event_type: EventType) -> None:
         del self._batch_delete_job[event_type.name]
@@ -682,9 +690,7 @@ class EventsPlugin(neon_player.Plugin):
             return
 
         logging.debug(f"Deleting all instances of event '{event_name}'")
-        del self._events[event_name]
-        self._update_workspace_index()
-        self.save_cached_json("events.json", self._events)
+        self.delete_events({event_name: self.events[event_name]})
 
     def _add_event(self, event_type: EventType, ts: int | None = None) -> None:
         if self.recording is None:
@@ -875,14 +881,10 @@ class EventsPlugin(neon_player.Plugin):
             logging.warning(f"Event type '{old_name}' not found for renaming")
             return
 
-        if self._batch_rename_job is not None:
+        if old_name in self._batch_rename_job:
             return
 
-        # NOTE: While renaming the events, we need both the old and new names to be
-        # present for events to load correctly. Once the renaming is complete, the
-        # old name can be removed from the event types.
         self._event_types_by_name[new_name] = event_type
-        self._event_types_by_name[old_name] = EventType.from_name(old_name)
         self._rename_all_events_by_name(old_name, new_name)
         if not self.headless:
             timeline = self.get_timeline()
@@ -896,16 +898,17 @@ class EventsPlugin(neon_player.Plugin):
                 timeline.enable_plot_sorting()
 
         if not self._consider_workspace:
-            self._rename_all_events_by_name(old_name, new_name)
-            self._finalize_event_rename(old_name)
             return
 
-        self._batch_rename_job = self.job_manager.run_background_batch_action(
+        batch_job = self.job_manager.run_background_batch_action(
             f"Rename events [{old_name} -> {new_name}]",
             "EventsPlugin._rename_all_events_by_name",
-            lambda _: [old_name, new_name]
+            lambda _: [old_name, new_name],
+            confirm_cancel=self.confirm_cancel_message(old_name)
         )
-        self._batch_rename_job.finished.connect(lambda: self._finalize_event_rename(old_name))
+        batch_job.finished.connect(lambda: self._on_batch_rename_finished(new_name))
+        batch_job.canceled.connect(lambda: self._on_batch_rename_finished(new_name))
+        self._batch_rename_job[new_name] = batch_job
 
     def _rename_all_events_by_name(self, old_name: str, new_name: str) -> None:
         if old_name not in self._events:
@@ -915,11 +918,8 @@ class EventsPlugin(neon_player.Plugin):
         self.save_cached_json("events.json", self._events)
         self._update_workspace_index()
 
-    def _finalize_event_rename(self, old_name: str) -> None:
-        if old_name in self._event_types_by_name:
-            del self._event_types_by_name[old_name]
-        self.changed.emit()
-        self._batch_rename_job = None
+    def _on_batch_rename_finished(self, new_name: str) -> None:
+        del self._batch_rename_job[new_name]
 
     @action
     @action_params(

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -459,6 +459,14 @@ class EventsPlugin(neon_player.Plugin):
         self._events = events
         logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
 
+        # If event type ID is different from the event name, make them match to
+        # align event types across recordings
+        event_types_changed = False
+        for event_type in self._event_types_by_name.values():
+            if event_type.uid != event_type.name:
+                event_type.uid = event_type.name
+                event_types_changed = True
+
         # NOTE: event types are loaded from plugin settings before this method is called,
         # so existing event types need to be preserved while adding missing ones.
         for event_name in events:
@@ -470,14 +478,8 @@ class EventsPlugin(neon_player.Plugin):
 
             new_event_type = EventType.from_name(event_name)
             self._event_types_by_name[event_name] = new_event_type
+            event_types_changed = True
 
-        # If event type ID is different from the event name, make them match to
-        # align event types across recordings
-        event_types_changed = False
-        for event_type in self._event_types_by_name.values():
-            if event_type.uid != event_type.name:
-                event_type.uid = event_type.name
-                event_types_changed = True
         if event_types_changed:
             self.changed.emit()
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -732,10 +732,10 @@ class EventsPlugin(neon_player.Plugin):
     def _find_closest_event(
         self, event_type: EventType, target_ts: int, tolerance_ns: int = 5
     ) -> int | None:
-        if event_type.uid not in self._events:
+        if event_type.name not in self._events:
             return None
 
-        events_list = self._events[event_type.uid]
+        events_list = self._events[event_type.name]
         if not events_list:
             return None
 
@@ -786,7 +786,7 @@ class EventsPlugin(neon_player.Plugin):
         if plot_item is None or not plot_item.items:
             return
 
-        x = np.array(self._events.get(event_type.uid, []))
+        x = np.array(self._events.get(event_type.name, []))
         y = np.zeros_like(x)
         plot_item.items[0].setData(x, y)
 
@@ -813,13 +813,7 @@ class EventsPlugin(neon_player.Plugin):
         as keys and lists of all timestamps for each event as values. For modifying
         events from other plugins, use add_events() and delete_events() methods.
         """
-        event_id_name_mapping = {et.uid: et.name for et in self.event_types}
-        events_by_name = {}
-        for event_id, timestamps in self._events.items():
-            # Use IDs as fallback for immutable events that are not included in event_types
-            event_name = event_id_name_mapping.get(event_id, event_id)
-            events_by_name[event_name] = timestamps
-        return events_by_name
+        return self._events
 
     def add_events(self, events: dict[str, list[int]]) -> None:
         """
@@ -842,9 +836,9 @@ class EventsPlugin(neon_player.Plugin):
                     )
                 event_types_to_update.append(event_type)
 
-            if event_type.uid not in self._events:
-                self._events[event_type.uid] = []
-            self._events[event_type.uid].extend(timestamps)
+            if event_type.name not in self._events:
+                self._events[event_type.name] = []
+            self._events[event_type.name].extend(timestamps)
 
         self.save_cached_json("events.json", self._events)
         self._update_workspace_index()
@@ -878,15 +872,15 @@ class EventsPlugin(neon_player.Plugin):
                 )
 
             event_type = self._event_types_by_name[event_name]
-            existing_timestamps = set(self._events[event_type.uid])
+            existing_timestamps = set(self._events[event_type.name])
             timestamps_to_remove = set(timestamps)
             remaining_timestamps = existing_timestamps - timestamps_to_remove
             if remaining_timestamps:
-                self._events[event_type.uid] = list(remaining_timestamps)
+                self._events[event_type.name] = list(remaining_timestamps)
                 event_types_to_update.append(event_type)
                 continue
 
-            del self._events[event_type.uid]
+            del self._events[event_type.name]
             if remove_empty_types:
                 del self._event_types_by_name[event_name]
                 event_types_to_remove.append(event_type)

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -455,6 +455,7 @@ class EventsPlugin(neon_player.Plugin):
         events = self._load_events_from_cache()
         if events is None:
             events = _load_events_from_recording(recording)
+            self.save_cached_json("events.json", events)
         self._events = events
         logging.info(f"Loaded {sum(len(v) for v in self._events.values())} events")
 

--- a/src/pupil_labs/neon_player/plugins/events.py
+++ b/src/pupil_labs/neon_player/plugins/events.py
@@ -370,6 +370,9 @@ class EventsPlugin(neon_player.Plugin):
         self.save_cached_json(self._index_file, data, workspace=True)
 
     def _update_workspace_index(self, load: bool = True, save: bool = True) -> None:
+        if not self._consider_workspace:
+            return
+
         if load:
             self._load_workspace_index()
         self._workspace_index.update(self.recording.id, self.events)
@@ -443,7 +446,7 @@ class EventsPlugin(neon_player.Plugin):
         """
         if not self.batch_mode_enabled:
             events = self.events.get(event_name, [])
-            return len(events), [self.recording._rec_dir.name] if events else []
+            return len(events), [self.recording.id] if events else []
 
         event_occurrences = self._workspace_index.events.get(event_name, {})
         return sum(event_occurrences.values()), list(event_occurrences.keys())
@@ -677,8 +680,8 @@ class EventsPlugin(neon_player.Plugin):
         if event_type.name not in self._event_types_by_name:
             return
 
-        del self._event_types_by_name[event_type.name]
         self._delete_events_by_name(event_type.name)
+        del self._event_types_by_name[event_type.name]
         self.changed.emit()
         if not self.headless:
             self._update_gui_for_event_types(event_types_to_remove=[event_type])
@@ -686,10 +689,17 @@ class EventsPlugin(neon_player.Plugin):
         if not self._consider_workspace:
             return
 
+        _, recording_ids = self._count_events_across_workspace(event_type.name)
+        other_recording_ids = set(recording_ids) - {self.recording.id}
+        other_recordings = self.workspace.get_recordings_by_id(other_recording_ids)
+        if not other_recordings:
+            return
+
         batch_job = self.job_manager.run_background_batch_action(
             f"Delete events [{event_type.name}]",
             "EventsPlugin._delete_events_by_name",
             args_generator=lambda _: [event_type.name],
+            recordings=other_recordings,
             confirm_cancel=self.confirm_cancel_message(event_type.name),
         )
         batch_job.finished.connect(lambda: self._on_batch_delete_finished(event_type))
@@ -836,9 +846,9 @@ class EventsPlugin(neon_player.Plugin):
                     )
                 event_types_to_update.append(event_type)
 
-            if event_type.name not in self._events:
-                self._events[event_type.name] = []
-            self._events[event_type.name].extend(timestamps)
+            if event_name not in self._events:
+                self._events[event_name] = []
+            self._events[event_name].extend(timestamps)
 
         self.save_cached_json("events.json", self._events)
         self._update_workspace_index()
@@ -861,7 +871,7 @@ class EventsPlugin(neon_player.Plugin):
         event_types_to_remove = []
         event_types_to_update = []
         for event_name, timestamps in events.items():
-            if event_name not in self._event_types_by_name:
+            if event_name not in self._events:
                 logging.warning(f"Skipping unknown event '{event_name}' from deletion")
                 continue
 
@@ -871,16 +881,16 @@ class EventsPlugin(neon_player.Plugin):
                     f"of this event cannot be deleted."
                 )
 
-            event_type = self._event_types_by_name[event_name]
-            existing_timestamps = set(self._events[event_type.name])
+            event_type = self._event_types_by_name.get(event_name, None)
+            existing_timestamps = set(self._events[event_name])
             timestamps_to_remove = set(timestamps)
             remaining_timestamps = existing_timestamps - timestamps_to_remove
             if remaining_timestamps:
-                self._events[event_type.name] = list(remaining_timestamps)
-                event_types_to_update.append(event_type)
+                self._events[event_name] = list(remaining_timestamps)
+                event_types_to_update.append(self._event_types_by_name[event_name])
                 continue
 
-            del self._events[event_type.name]
+            del self._events[event_name]
             if remove_empty_types:
                 del self._event_types_by_name[event_name]
                 event_types_to_remove.append(event_type)
@@ -922,10 +932,17 @@ class EventsPlugin(neon_player.Plugin):
         if not self._consider_workspace:
             return
 
+        _, recording_ids = self._count_events_across_workspace(event_type.name)
+        other_recording_ids = set(recording_ids) - {self.recording.id}
+        other_recordings = self.workspace.get_recordings_by_id(other_recording_ids)
+        if not other_recordings:
+            return
+
         batch_job = self.job_manager.run_background_batch_action(
             f"Rename events [{old_name} -> {new_name}]",
             "EventsPlugin._rename_all_events_by_name",
-            lambda _: [old_name, new_name],
+            args_generator=lambda _: [old_name, new_name],
+            recordings=other_recordings,
             confirm_cancel=self.confirm_cancel_message(old_name)
         )
         batch_job.finished.connect(lambda: self._on_batch_rename_finished(new_name))

--- a/src/pupil_labs/neon_player/settings.py
+++ b/src/pupil_labs/neon_player/settings.py
@@ -385,7 +385,7 @@ class PluginSettingsDispatcher(QObject):
             workspace_states,
             recording_states,
             scopes=self.property_scopes,
-            overwrite_condition=lambda scopes: "recording" in scopes
+            overwrite_condition=lambda scopes: scopes == ["recording"]
         )
 
         return combined_states

--- a/src/pupil_labs/neon_player/ui/console.py
+++ b/src/pupil_labs/neon_player/ui/console.py
@@ -109,11 +109,11 @@ class JobProgressBar(QWidget):
         self.progress_bar.setValue(v * 100)
 
     def on_cancel_clicked(self):
-        if self.worker.warn_on_cancel:
+        if self.worker.confirm_cancel:
             result = QMessageBox.question(
                 None,
                 "Cancel Job",
-                self.worker.warn_on_cancel,
+                self.worker.confirm_cancel,
             )
 
             if result != QMessageBox.StandardButton.Yes:

--- a/src/pupil_labs/neon_player/ui/console.py
+++ b/src/pupil_labs/neon_player/ui/console.py
@@ -5,6 +5,7 @@ from PySide6.QtCore import Qt, QTimer
 from PySide6.QtWidgets import (
     QFormLayout,
     QHBoxLayout,
+    QMessageBox,
     QProgressBar,
     QPushButton,
     QSizePolicy,
@@ -97,7 +98,7 @@ class JobProgressBar(QWidget):
         self.cancel_button = QToolButton()
         self.cancel_button.setText("🗑")
         self.cancel_button.setAutoRaise(True)
-        self.cancel_button.clicked.connect(job.cancel)
+        self.cancel_button.clicked.connect(self.on_cancel_clicked)
         self.main_layout.addWidget(self.cancel_button)
 
         self.worker = job
@@ -106,6 +107,19 @@ class JobProgressBar(QWidget):
     def on_worker_progress(self, v: float):
         self.progress_bar.setRange(0, 100)
         self.progress_bar.setValue(v * 100)
+
+    def on_cancel_clicked(self):
+        if self.worker.warn_on_cancel:
+            result = QMessageBox.question(
+                None,
+                "Cancel Job",
+                self.worker.warn_on_cancel,
+            )
+
+            if result != QMessageBox.StandardButton.Yes:
+                return
+
+        self.worker.cancel()
 
 
 class ConsoleWindow(QWidget):

--- a/src/pupil_labs/neon_player/utilities.py
+++ b/src/pupil_labs/neon_player/utilities.py
@@ -157,6 +157,10 @@ class SignalDebouncer:
         debouncer.args = args
         debouncer.timer.start(delay * 1000)
 
+    @staticmethod
+    def get_pending_debouncer(signal: Signal) -> T.Optional["SignalDebouncer"]:
+        return SignalDebouncer._signal_debouncer_map.get(signal)
+
     def __init__(self, signal: Signal):
         self.signal = signal
         self.timer = QTimer()

--- a/src/pupil_labs/neon_player/workspace.py
+++ b/src/pupil_labs/neon_player/workspace.py
@@ -1,5 +1,6 @@
 import logging
 
+from collections.abc import Iterable
 from dataclasses import dataclass
 from datetime import datetime, timedelta
 from pathlib import Path
@@ -85,6 +86,9 @@ class Workspace(QObject):
     @property
     def recording_metadata(self) -> list[RecordingMetadata]:
         return list(self._recording_metadata.values())
+
+    def get_recordings_by_id(self, recording_ids: Iterable[str]) -> list[NeonRecording]:
+        return [rec for rec in self._recordings if rec.id in recording_ids]
 
     def get_recording_path(self, recording_name: str) -> Path | None:
         """

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -46,35 +46,6 @@ def test_events__load_events_from_recording(mock_neon_recording):
     assert events == events_dict, "Expected events to match the recording events"
 
 
-def test_events__load_events_from_cache():
-    # Should not contain recording.begin / recording.end as these types are
-    # not stored in the settings file
-    event_names = [
-        "trial.begin", "trial.end", "extra.event"
-    ]
-    event_types = []
-    for idx, event_name in enumerate(event_names):
-        et = EventType()
-        et._name = event_name
-        et._uid = event_name if "recording" in event_name else f"uid{idx}"
-        event_types.append(et)
-
-    cached_events = {
-        "recording.begin": [0],
-        "uid0": [100, 400, 700],  # trial.begin
-        "uid1": [200, 500, 800],  # trial.end
-        "recording.end": [1000],
-    }
-
-    event_types, events = _load_events_from_cache(cached_events, event_types)
-
-    assert len(event_types) == 4
-    for et in event_types:
-        assert et in event_types, f"Expected known event types to be used"
-        assert et.name != "extra.event", "Only present event types should be returned"
-    assert events == cached_events, "Expected events to match cached events"
-
-
 def test_events__load_events_from_dataframe():
     events_df = pd.DataFrame({
         "name": [
@@ -91,14 +62,59 @@ def test_events__load_events_from_dataframe():
         assert events[event_name] == ts, f"Wrong timestamp for {event_name}"
 
 
+def test_events_plugin__load_events_from_cache__old_format():
+    """
+    Event type IDs in the cached events dict are replaced with their corresponding names
+    using the mapping returned by _get_uid_name_mapping.
+    """
+    cached_events = {
+        "recording.begin": [0],
+        "uid0": [100, 400, 700],
+        "uid1": [200, 500, 800],
+        "recording.end": [1000],
+    }
+    uid_name_mapping = {
+        "uid0": "trial.begin",
+        "uid1": "trial.end",
+    }
+    expected_events = cached_events.copy()
+    expected_events["trial.begin"] = expected_events.pop("uid0")
+    expected_events["trial.end"] = expected_events.pop("uid1")
+
+    plugin = EventsPlugin()
+    plugin.load_cached_json = MagicMock(return_value=cached_events)
+    plugin._get_uid_name_mapping = MagicMock(return_value=uid_name_mapping)
+    events = plugin._load_events_from_cache()
+
+    assert events == expected_events
+
+
+def test_events_plugin__load_events_from_cache__new_format():
+    cached_events = {
+        "recording.begin": [0],
+        "trial_begin": [100, 400, 700],
+        "trial_end": [200, 500, 800],
+        "recording.end": [1000],
+    }
+    uid_name_mapping = {}
+
+    plugin = EventsPlugin()
+    plugin.load_cached_json = MagicMock(return_value=cached_events)
+    plugin._get_uid_name_mapping = MagicMock(return_value=uid_name_mapping)
+    events = plugin._load_events_from_cache()
+
+    assert events == cached_events
+
+
 @patch(
     "pupil_labs.neon_player.plugins.events._load_events_from_recording",
     return_value={"test.event": [100, 200, 300]}
 )
-def test_events_plugin__on_recording_loaded__from_recording(mock_load_events, mock_neon_recording):
+def test_events_plugin__on_recording_loaded__from_recording(mock_load_events, qtbot, mock_neon_recording):
     plugin = EventsPlugin()
     plugin.save_cached_json = MagicMock()
-    plugin.on_recording_loaded(mock_neon_recording())
+    with qtbot.waitSignal(plugin.changed):
+        plugin.on_recording_loaded(mock_neon_recording())
 
     mock_load_events.assert_called_once()
     assert "test.event" in plugin._event_types_by_name, \
@@ -108,18 +124,45 @@ def test_events_plugin__on_recording_loaded__from_recording(mock_load_events, mo
     plugin.save_cached_json.assert_called_once()
 
 
-def test_events_plugin__on_recording_loaded__from_cache(mock_neon_recording):
-    et = EventType.from_name("test.event")
+def test_events_plugin__on_recording_loaded__from_cache_old_format(qtbot, mock_neon_recording):
+    cached_events = {
+        "recording.begin": [0],
+        "trial": [100, 400, 700],
+        "recording.end": [1000],
+    }
+
+    # Simulate old format where event type ID is different from the name
+    et_begin = EventType.from_name("trial")
+    et_begin.uid = "uid0"
 
     plugin = EventsPlugin()
-    plugin._load_events = MagicMock(
-        return_value=([et], {et.uid: [100, 200, 300]}, "cache")
-    )
+    plugin.event_types = [et_begin]
+    plugin._load_events_from_cache = MagicMock(return_value=cached_events)
     plugin.save_cached_json = MagicMock()
-    plugin.on_recording_loaded(mock_neon_recording())
+    with qtbot.waitSignal(plugin.changed):
+        plugin.on_recording_loaded(mock_neon_recording())
 
-    assert plugin.event_types == [], "Expected event types not to be modified"
-    assert plugin._events == {et.uid: [100, 200, 300]}, "Expected events to be loaded from cache"
+    assert plugin.event_types[0].uid == "trial", "Expected event type ID to match its name"
+    assert plugin._events["trial"] == [100, 400, 700], "Expected events to be loaded from cache"
+    plugin.save_cached_json.assert_not_called()
+
+
+def test_events_plugin__on_recording_loaded__from_cache_new_format(qtbot, mock_neon_recording):
+    cached_events = {
+        "recording.begin": [0],
+        "trial": [100, 400, 700],
+        "recording.end": [1000],
+    }
+    et_begin = EventType.from_name("trial")
+
+    plugin = EventsPlugin()
+    plugin.event_types = [et_begin]
+    plugin._load_events_from_cache = MagicMock(return_value=cached_events)
+    plugin.save_cached_json = MagicMock()
+    with qtbot.assertNotEmitted(plugin.changed):
+        plugin.on_recording_loaded(mock_neon_recording())
+
+    assert plugin._events["trial"] == [100, 400, 700], "Expected events to be loaded from cache"
     plugin.save_cached_json.assert_not_called()
 
 

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -5,7 +5,6 @@ import pytest
 from unittest.mock import MagicMock, patch
 
 from pupil_labs.neon_player.plugins.events import (
-    _load_events_from_cache,
     _load_events_from_recording,
     _load_events_from_dataframe,
     EventType,
@@ -43,21 +42,8 @@ def test_events__load_events_from_recording(mock_neon_recording):
     mock_events = mock_event_timeseries(events_dict)
     recording = mock_neon_recording(events=mock_events)
 
-    event_types, events = _load_events_from_recording(recording)
-    assert len(event_types) == 4
-    assert len(events) == 4
-
-    for event_name in ["recording.begin", "trial.begin", "trial.end", "recording.end"]:
-        et = [et for et in event_types if et.name == event_name]
-        assert len(et) == 1, f"Expected exactly one event type for {event_name}, got {len(et)}"
-        et = et[0]
-
-        assert et.name == event_name
-        if "recording" in event_name:
-            assert et.uid == event_name, "Expected uid to match name for immutable events"
-
-        assert events[et.uid] == events_dict[event_name], \
-            f"Timestamps for {event_name} do not match input data"
+    events = _load_events_from_recording(recording)
+    assert events == events_dict, "Expected events to match the recording events"
 
 
 def test_events__load_events_from_cache():

--- a/tests/test_plugins/test_events.py
+++ b/tests/test_plugins/test_events.py
@@ -91,18 +91,20 @@ def test_events__load_events_from_dataframe():
         assert events[event_name] == ts, f"Wrong timestamp for {event_name}"
 
 
-def test_events_plugin__on_recording_loaded__from_recording(mock_neon_recording):
-    et = EventType.from_name("test.event")
-
+@patch(
+    "pupil_labs.neon_player.plugins.events._load_events_from_recording",
+    return_value={"test.event": [100, 200, 300]}
+)
+def test_events_plugin__on_recording_loaded__from_recording(mock_load_events, mock_neon_recording):
     plugin = EventsPlugin()
-    plugin._load_events = MagicMock(
-        return_value=([et], {et.uid: [100, 200, 300]}, "recording")
-    )
     plugin.save_cached_json = MagicMock()
     plugin.on_recording_loaded(mock_neon_recording())
 
-    assert plugin.event_types == [et], "Expected event types to be loaded from recording"
-    assert plugin._events == {et.uid: [100, 200, 300]}, "Expected events to be loaded from recording"
+    mock_load_events.assert_called_once()
+    assert "test.event" in plugin._event_types_by_name, \
+        "Expected event type to be created from recording"
+    assert plugin._events == {"test.event": [100, 200, 300]}, \
+        "Expected events to be loaded from recording"
     plugin.save_cached_json.assert_called_once()
 
 
@@ -188,14 +190,22 @@ def test_events_plugin__on_event_name_changed():
     plugin = EventsPlugin()
     et = EventType.from_name("test.event")
     plugin.event_types = [et]
+    plugin._events = {"test.event": [100, 200, 300]}
 
     et._name = "renamed.event"
 
     # Simulate the name_changed signal being emitted
-    plugin._on_event_name_changed("test.event", "renamed.event", et)
+    plugin._on_event_name_changed("test.event", "renamed.event")
 
     assert "test.event" not in plugin._event_types_by_name
+    assert "test.event" not in plugin._events
     assert "renamed.event" in plugin._event_types_by_name
+    assert "renamed.event" in plugin._events
+
+    assert plugin._event_types_by_name["renamed.event"] is et, \
+        "Expected event type to be preserved under the new name"
+    assert plugin._events["renamed.event"] == [100, 200, 300], \
+        "Expected events to be preserved under the new event type name"
 
 
 def test_events_plugin__add_events__adds_new_event_types(qtbot):


### PR DESCRIPTION
New functionality:

- [x] load events from other recordings when opening the workspace for the first time
- [x] load and merge events from cache files correctly 
- [x] run batch rename in background
- [x] run batch delete in background
- [x] run batch export in background
- [x] share event types and keyboard shortcuts across the workspace
- [x] update workspace event index on in-app event modification

Background job specifics:

* batch rename and batch delete leave an inconsistent state across recordings if canceled mid-way - added a warning
* event type is blocked for renaming if a batch rename job is already running for it
* otherwise, it should be possible to switch between recordings while the background jobs are still running