### PR TITLE
chore(app): reuse Plugin objects within workspace session

### DIFF
--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -204,7 +204,7 @@ class NeonPlayerApp(QApplication):
 
         self.aboutToQuit.connect(self.unload)
 
-    def run_jobs(self, job):
+    def run_jobs(self, job) -> None:
         plugin_name, action_name = job[0].split(".")
         job_args = job[1:]
 
@@ -349,14 +349,14 @@ class NeonPlayerApp(QApplication):
         enabled: bool,
         state: dict | None = None,
         delete: bool = True
-    ) -> Plugin | None:
+    ) -> None:
         if isinstance(kls, str):
             try:
                 kls = Plugin.get_class_by_name(kls)
             except ValueError:
                 if enabled:
                     logging.warning(f"Couldn't enable plugin class: {kls}")
-                return None
+                return
 
         plugin_exists = kls.__name__ in self.plugins_by_class
         if plugin_exists and not isinstance(self.plugins_by_class[kls.__name__], kls):
@@ -372,7 +372,7 @@ class NeonPlayerApp(QApplication):
                 if plugin_exists:
                     plugin = self.plugins_by_class[kls.__name__]
                 else:
-                    plugin: Plugin = kls.from_dict(state)
+                    plugin = kls.from_dict(state)
                     self.plugins_by_class[kls.__name__] = plugin
 
                     plugin.changed.connect(self.main_window.video_widget.update)
@@ -385,7 +385,7 @@ class NeonPlayerApp(QApplication):
                 plugin._enabled = True
             except Exception:
                 logging.exception(f"Failed to enable plugin {kls}")
-                return None
+                return
 
         elif not enabled and currently_enabled:
             plugin = self.plugins_by_class[kls.__name__]

--- a/src/pupil_labs/neon_player/app.py
+++ b/src/pupil_labs/neon_player/app.py
@@ -348,6 +348,7 @@ class NeonPlayerApp(QApplication):
         kls: type[Plugin] | str,
         enabled: bool,
         state: dict | None = None,
+        delete: bool = True
     ) -> Plugin | None:
         if isinstance(kls, str):
             try:
@@ -357,7 +358,10 @@ class NeonPlayerApp(QApplication):
                     logging.warning(f"Couldn't enable plugin class: {kls}")
                 return None
 
-        currently_enabled = kls.__name__ in self.plugins_by_class
+        plugin_exists = kls.__name__ in self.plugins_by_class
+        if plugin_exists and not isinstance(self.plugins_by_class[kls.__name__], kls):
+            raise RuntimeError(f"Invalid instance of plugin found: {kls.__name__}")
+        currently_enabled = plugin_exists and self.plugins_by_class[kls.__name__]._enabled
 
         if enabled and not currently_enabled:
             logging.info(f"Enabling plugin: {kls.__name__}")
@@ -365,16 +369,20 @@ class NeonPlayerApp(QApplication):
                 if state is None:
                     state = self.session_settings.plugin_states.get(kls.__name__, {})
 
-                plugin: Plugin = kls.from_dict(state)
+                if plugin_exists:
+                    plugin = self.plugins_by_class[kls.__name__]
+                else:
+                    plugin: Plugin = kls.from_dict(state)
+                    self.plugins_by_class[kls.__name__] = plugin
 
-                self.plugins_by_class[kls.__name__] = plugin
+                    plugin.changed.connect(self.main_window.video_widget.update)
+                    SlotDebouncer.debounce(plugin.changed, self.save_settings)
+
                 self.main_window.settings_panel.add_plugin_settings(plugin)
-
-                plugin.changed.connect(self.main_window.video_widget.update)
-                SlotDebouncer.debounce(plugin.changed, self.save_settings)
-
                 if self.recording:
                     plugin.on_recording_loaded(self.recording)
+
+                plugin._enabled = True
             except Exception:
                 logging.exception(f"Failed to enable plugin {kls}")
                 return None
@@ -383,13 +391,16 @@ class NeonPlayerApp(QApplication):
             plugin = self.plugins_by_class[kls.__name__]
 
             plugin.on_disabled()
-            plugin.deleteLater()
-            del self.plugins_by_class[kls.__name__]
+            plugin._enabled = False
             self.main_window.settings_panel.remove_plugin_settings(kls.__name__)
+            if delete:
+                plugin.on_deleted()
+                plugin.deleteLater()
+                del self.plugins_by_class[kls.__name__]
 
             logging.info(f"Disabled plugin: {kls.__name__}")
 
-        self.plugins = list(self.plugins_by_class.values())
+        self.plugins = [p for p in self.plugins_by_class.values() if p._enabled]
         self.plugins.sort(key=lambda p: p.render_layer)
 
         self.main_window.video_widget.update()
@@ -429,12 +440,12 @@ class NeonPlayerApp(QApplication):
 
     def unload(self) -> None:
         if self.recording:
-            self.unload_recording()
+            self.unload_recording(delete_plugins=True)
 
         self.workspace.clear()
         self.workspace_unloaded.emit()
 
-    def unload_recording(self) -> None:
+    def unload_recording(self, delete_plugins: bool = False) -> None:
         self.set_playback_state(False)
         self.save_settings(force=True)
         class_names = list(self.plugins_by_class.keys())
@@ -442,7 +453,7 @@ class NeonPlayerApp(QApplication):
         timeline = self.main_window.timeline
         timeline.disable_plot_sorting()
         for plugin_class_name in class_names:
-            self.toggle_plugin(plugin_class_name, False)
+            self.toggle_plugin(plugin_class_name, False, delete=delete_plugins)
         timeline.enable_plot_sorting()
 
         if self.recording is not None:

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -192,11 +192,6 @@ class Plugin(PersistentPropertiesMixin, QObject):
 
     @property
     @property_params(widget=None, dont_encode=True)
-    def batch_mode_enabled(self) -> bool:
-        return getattr(self.app, "batch_mode_enabled", False)
-
-    @property
-    @property_params(widget=None, dont_encode=True)
     def workspace(self) -> "Workspace":
         return neon_player.instance().workspace
 

--- a/src/pupil_labs/neon_player/plugins/__init__.py
+++ b/src/pupil_labs/neon_player/plugins/__init__.py
@@ -111,6 +111,9 @@ class Plugin(PersistentPropertiesMixin, QObject):
     def on_disabled(self) -> None:
         pass
 
+    def on_deleted(self) -> None:
+        pass
+
     def trigger_scene_update(self) -> None:
         self.app.main_window.video_widget.update()
 
@@ -186,6 +189,11 @@ class Plugin(PersistentPropertiesMixin, QObject):
     @property_params(widget=None, dont_encode=True)
     def app(self) -> "NeonPlayerApp":
         return neon_player.instance()
+
+    @property
+    @property_params(widget=None, dont_encode=True)
+    def batch_mode_enabled(self) -> bool:
+        return getattr(self.app, "batch_mode_enabled", False)
 
     @property
     @property_params(widget=None, dont_encode=True)

--- a/src/pupil_labs/neon_player/plugins/audio.py
+++ b/src/pupil_labs/neon_player/plugins/audio.py
@@ -1,5 +1,6 @@
 import av
 import fractions
+import logging
 import numpy as np
 import typing as T
 
@@ -54,7 +55,7 @@ class AudioPlugin(neon_player.Plugin):
         self.app.seeked.connect(self.on_user_seeked)
         self.app.speed_changed.connect(self.on_speed_changed)
 
-        self.cache_file = Path()
+        self.cache_file: Path | None = None
 
         self.volume_button = VolumeButton()
         self.volume_button.setIconSize(QSize(32, 32))
@@ -145,7 +146,7 @@ class AudioPlugin(neon_player.Plugin):
             self.load_audio()
 
     def load_audio(self) -> None:
-        if not self.cache_file.exists():
+        if self.cache_file is None or not self.cache_file.exists():
             return
 
         self.recording_has_audio = True
@@ -164,6 +165,10 @@ class AudioPlugin(neon_player.Plugin):
         timeline.add_timeline_line("Audio", data)
 
     def extract_audio(self) -> T.Generator[ProgressUpdate, None, None]:
+        if self.cache_file is None:
+            logging.warning("Cache file path is not set. Cannot extract audio.")
+            return
+
         self.cache_file.parent.mkdir(parents=True, exist_ok=True)
 
         container = av.open(str(self.cache_file), "w")

--- a/src/pupil_labs/neon_player/plugins/audio.py
+++ b/src/pupil_labs/neon_player/plugins/audio.py
@@ -3,6 +3,7 @@ import fractions
 import numpy as np
 import typing as T
 
+from pathlib import Path
 from PySide6.QtCore import QSize, Qt, QTimer, QUrl, Signal
 from PySide6.QtGui import QPixmap
 from PySide6.QtMultimedia import QAudioOutput, QMediaPlayer
@@ -53,7 +54,7 @@ class AudioPlugin(neon_player.Plugin):
         self.app.seeked.connect(self.on_user_seeked)
         self.app.speed_changed.connect(self.on_speed_changed)
 
-        self.cache_file = self.get_cache_path() / "audio.wav"
+        self.cache_file = Path()
 
         self.volume_button = VolumeButton()
         self.volume_button.setIconSize(QSize(32, 32))
@@ -65,6 +66,8 @@ class AudioPlugin(neon_player.Plugin):
         self.player.stop()
         self.player.setSource(QUrl())
         self.get_timeline().remove_timeline_plot("Audio")
+
+    def on_deleted(self) -> None:
         self.get_timeline().toolbar_layout.removeWidget(self.volume_button)
         self.volume_button.deleteLater()
 
@@ -124,6 +127,8 @@ class AudioPlugin(neon_player.Plugin):
             self.player.play()
 
     def on_recording_loaded(self, recording: NeonRecording) -> None:
+        self.cache_file = self.get_cache_path() / "audio.wav"
+
         self.recording_has_audio = False
         if not self.cache_file.exists():
             if self.app.headless:

--- a/src/pupil_labs/neon_player/plugins/fixations.py
+++ b/src/pupil_labs/neon_player/plugins/fixations.py
@@ -157,6 +157,8 @@ class FixationsPlugin(neon_player.Plugin):
         return self.gaze_plugin.offset_x, self.gaze_plugin.offset_y
 
     def on_disabled(self) -> None:
+        self.flow_dict = {}
+
         self.get_timeline().remove_timeline_plot("Fixations")
         self.unregister_action("Playback/Next Fixation")
         self.unregister_action("Playback/Previous Fixation")

--- a/src/pupil_labs/neon_player/plugins/imu.py
+++ b/src/pupil_labs/neon_player/plugins/imu.py
@@ -53,6 +53,8 @@ class IMUPlugin(neon_player.Plugin):
         self.update_plots()
 
     def on_disabled(self) -> None:
+        self.imu_data = None
+
         timeline = self.get_timeline()
         for name in ["IMU - Orientation", "IMU - Gyroscope", "IMU - Acceleration"]:
             timeline.remove_timeline_plot(name)

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
@@ -133,7 +133,8 @@ class SurfaceTrackingPlugin(Plugin):
 
     def __init__(self) -> None:
         super().__init__()
-        self.marker_cache_file = Path("")
+        self.marker_cache_file: Path | None = None
+        self.camera: Camera | None = None
 
         self._draw_marker_ids = False
         self._draw_names = True
@@ -223,6 +224,9 @@ class SurfaceTrackingPlugin(Plugin):
         self.attempt_marker_cache_load()
 
     def attempt_marker_cache_load(self) -> None:
+        if self.marker_cache_file is None:
+            return
+
         if self.marker_cache_file.exists():
             self._load_marker_cache()
             return
@@ -448,6 +452,10 @@ class SurfaceTrackingPlugin(Plugin):
             painter.setPen(old_pen)
 
     def _load_marker_cache(self) -> None:
+        if self.marker_cache_file is None:
+            logging.warning("Marker cache file path is not set. Cannot load marker cache.")
+            return
+
         self.markers_by_frame = np.load(self.marker_cache_file, allow_pickle=True)
         self.trigger_scene_update()
         for frame_markers in self.markers_by_frame:

--- a/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
+++ b/src/pupil_labs/neon_player/plugins/surface_tracking/surface_tracking.py
@@ -133,8 +133,7 @@ class SurfaceTrackingPlugin(Plugin):
 
     def __init__(self) -> None:
         super().__init__()
-        self.marker_cache_file = self.get_cache_path() / "markers.npy"
-        self.surface_cache_file = self.get_cache_path() / "surfaces.npy"
+        self.marker_cache_file = Path("")
 
         self._draw_marker_ids = False
         self._draw_names = True
@@ -219,6 +218,8 @@ class SurfaceTrackingPlugin(Plugin):
             self.recording.calibration.scene_camera_matrix,
             self.recording.calibration.scene_distortion_coefficients,
         )
+
+        self.marker_cache_file = self.get_cache_path() / "markers.npy"
         self.attempt_marker_cache_load()
 
     def attempt_marker_cache_load(self) -> None:


### PR DESCRIPTION
* Plugin objects are now not deleted when switching between recordings within a workspace
* Plugin objects are still deleted when exiting workspace or disabling a plugin in settings
* new `Plugin.on_deleted` method for cleaning up resources / objects created in the constructor (e.g., volume button for the audio plugin)